### PR TITLE
Refactor(#23): 캘린더 컴포넌트 커스텀 훅으로 분리

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,12 +2,12 @@
 
 import { useState } from "react";
 import KakaoIcon from "@/assets/images/icons/kakao.svg";
-import Calendar from "@/components/common/Calendar";
 import ETCButton from "@/components/common/buttons/ETCButton";
 import IconButton from "@/components/common/buttons/IconButton";
 import OutlinePrimaryButton from "@/components/common/buttons/OutlinePrimaryButton";
 import OutlineSecondaryButton from "@/components/common/buttons/OutlineSecondaryButton";
 import SolidButton from "@/components/common/buttons/SolidButton";
+import Calendar from "@/components/common/Calendar";
 import Dropdown from "@/components/common/Dropdown";
 import Popover from "@/components/common/Popover";
 
@@ -229,7 +229,7 @@ export default function Home() {
       </div>
 
       {/* calendar */}
-      <div className='mx-auto h-max w-[368px] bg-gray-900 p-4'>
+      <div className='mx-auto w-fit bg-gray-900'>
         <Calendar onDateChange={(date) => setSelectedDate(date)} />
       </div>
 

--- a/src/components/common/Calendar.tsx
+++ b/src/components/common/Calendar.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
 import ArrowIcon from "@/assets/images/icons/arrow_left.svg";
-import generateCalendar from "@/utils/generateCalendar";
+import { useCalendar } from "@/hooks/useCalendar";
 
 const WEEK = {
   style: "flex flex-1 items-center justify-center",
@@ -28,52 +27,20 @@ interface CalendarProps {
 }
 
 export default function Calendar({ onDateChange }: CalendarProps) {
-  const today = new Date();
-  const [year, setYear] = useState(today.getFullYear());
-  const [month, setMonth] = useState(today.getMonth());
-  const [startDate, setStartDate] = useState<Date | null>(null);
-  const [endDate, setEndDate] = useState<Date | null>(null);
-
-  const { prevDates, currentDates, nextDates } = generateCalendar(year, month);
-
-  const handlePrevMonth = () => {
-    setMonth((prev) => (prev === 0 ? 11 : prev - 1));
-    if (month === 0) setYear((prev) => prev - 1);
-  };
-
-  const handleNextMonth = () => {
-    setMonth((prev) => (prev === 11 ? 0 : prev + 1));
-    if (month === 11) setYear((prev) => prev + 1);
-  };
-
-  const handleDateClick = ({
-    date,
-    state = "current",
-  }: {
-    date: number;
-    state?: "prev" | "next" | "current";
-  }) => {
-    let selectedDate = new Date(year, month, date);
-    if (state === "prev") selectedDate = new Date(year, month - 1, date);
-    if (state === "next") selectedDate = new Date(year, month + 1, date);
-
-    if (!startDate || (startDate && endDate)) {
-      setStartDate(selectedDate);
-      setEndDate(null);
-    } else {
-      if (selectedDate > startDate) {
-        setEndDate(selectedDate);
-      } else {
-        setStartDate(selectedDate);
-        setEndDate(null);
-      }
-    }
-
-    onDateChange?.({
-      startDate: startDate,
-      endDate: startDate && selectedDate > startDate ? selectedDate : null,
-    });
-  };
+  const {
+    year,
+    month,
+    prevDates,
+    currentDates,
+    nextDates,
+    handlePrevMonth,
+    handleNextMonth,
+    handleDateClick,
+    isSelected,
+    isInRange,
+    isRangeStart,
+    isRangeEnd,
+  } = useCalendar({ onDateChange });
 
   const getDateWrapperStyles = (
     date: number,
@@ -83,9 +50,14 @@ export default function Calendar({ onDateChange }: CalendarProps) {
     const isPrevNext = state === "prev" || state === "next";
     const base = `${DATE_STYLE.base} ${isPrevNext ? DATE_STYLE.prevNext : ""}`;
 
+    const isLastIndex =
+      (state === "current" && index === currentDates.length - 1) ||
+      (state === "next" && index === nextDates.length - 1);
+
     const rangeStart =
       isRangeStart({ date, state }) &&
-      (!isRangeEnd({ date, state }) || (prevDates.length + index) % 7 === 0)
+      (!isRangeEnd({ date, state }) || (prevDates.length + index) % 7 === 0) &&
+      !isLastIndex
         ? DATE_STYLE.rangeStart
         : "";
     const rangeEnd =
@@ -131,78 +103,17 @@ export default function Calendar({ onDateChange }: CalendarProps) {
     return [base, selected, inRange].filter(Boolean).join(" ");
   };
 
-  const isSelected = ({
-    date,
-    state = "current",
-  }: {
-    date: number;
-    state?: "prev" | "next" | "current";
-  }) => {
-    let selectedDate = new Date(year, month, date);
-    if (state === "prev") selectedDate = new Date(year, month - 1, date);
-    if (state === "next") selectedDate = new Date(year, month + 1, date);
-    return (
-      (startDate && selectedDate.toDateString() === startDate.toDateString()) ||
-      (endDate && selectedDate.toDateString() === endDate.toDateString())
-    );
-  };
-
-  const isInRange = ({
-    date,
-    state = "current",
-  }: {
-    date: number;
-    state?: "prev" | "next" | "current";
-  }) => {
-    let selectedDate = new Date(year, month, date);
-    if (state === "prev") selectedDate = new Date(year, month - 1, date);
-    if (state === "next") selectedDate = new Date(year, month + 1, date);
-    return (
-      startDate && endDate && selectedDate > startDate && selectedDate < endDate
-    );
-  };
-
-  const isRangeStart = ({
-    date,
-    state = "current",
-  }: {
-    date: number;
-    state?: "prev" | "next" | "current";
-  }) => {
-    let selectedDate = new Date(year, month, date);
-    if (state === "prev") selectedDate = new Date(year, month - 1, date);
-    if (state === "next") selectedDate = new Date(year, month + 1, date);
-    return (
-      startDate &&
-      endDate &&
-      selectedDate.toDateString() === startDate.toDateString()
-    );
-  };
-
-  const isRangeEnd = ({
-    date,
-    state = "current",
-  }: {
-    date: number;
-    state?: "prev" | "next" | "current";
-  }) => {
-    let selectedDate = new Date(year, month, date);
-    if (state === "prev") selectedDate = new Date(year, month - 1, date);
-    if (state === "next") selectedDate = new Date(year, month + 1, date);
-    return endDate && selectedDate.toDateString() === endDate.toDateString();
-  };
-
   return (
-    <div className='flex flex-col items-center gap-2 font-medium'>
+    <div className='flex w-[23rem] flex-col items-center gap-2 p-4 font-medium'>
       <div className='flex w-full items-center justify-between text-gray-100'>
         <button className='size-6' onClick={handlePrevMonth}>
-          <ArrowIcon className='size-full text-gray-300' />
+          <ArrowIcon className='size-full text-gray-100 disabled:text-gray-300' />
         </button>
         <div className='text-body-1-normal'>
           {year}년 {month + 1}월
         </div>
         <button className='size-6' onClick={handleNextMonth}>
-          <ArrowIcon className='size-full rotate-180 text-gray-300' />
+          <ArrowIcon className='size-full rotate-180 text-gray-100 disabled:text-gray-300' />
         </button>
       </div>
 

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -51,7 +51,7 @@ export function useCalendar({ onDateChange }: UseCalendarProps) {
     }
 
     onDateChange?.({
-      startDate: startDate && endDate ? selectedDate : startDate,
+      startDate: startDate ? startDate : selectedDate,
       endDate:
         startDate && selectedDate > startDate && !endDate ? selectedDate : null,
     });

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import generateCalendar from "@/utils/generateCalendar";
+
+interface UseCalendarProps {
+  onDateChange?: (dates: {
+    startDate: Date | null;
+    endDate: Date | null;
+  }) => void;
+}
+
+export function useCalendar({ onDateChange }: UseCalendarProps) {
+  const today = new Date();
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth());
+  const [startDate, setStartDate] = useState<Date | null>(null);
+  const [endDate, setEndDate] = useState<Date | null>(null);
+
+  const { prevDates, currentDates, nextDates } = generateCalendar(year, month);
+
+  const handlePrevMonth = () => {
+    setMonth((prev) => (prev === 0 ? 11 : prev - 1));
+    if (month === 0) setYear((prev) => prev - 1);
+  };
+
+  const handleNextMonth = () => {
+    setMonth((prev) => (prev === 11 ? 0 : prev + 1));
+    if (month === 11) setYear((prev) => prev + 1);
+  };
+
+  const handleDateClick = ({
+    date,
+    state = "current",
+  }: {
+    date: number;
+    state?: "prev" | "next" | "current";
+  }) => {
+    const selectedDate = getSelectedDate(year, month, date, state);
+
+    if (startDate && endDate) {
+      setStartDate(selectedDate);
+      setEndDate(null);
+    } else if (!startDate) {
+      setStartDate(selectedDate);
+    } else {
+      if (selectedDate > startDate) {
+        setEndDate(selectedDate);
+      } else {
+        setStartDate(selectedDate);
+        setEndDate(null);
+      }
+    }
+
+    onDateChange?.({
+      startDate: startDate && endDate ? selectedDate : startDate,
+      endDate:
+        startDate && selectedDate > startDate && !endDate ? selectedDate : null,
+    });
+  };
+
+  const isSelected = ({
+    date,
+    state = "current",
+  }: {
+    date: number;
+    state?: "prev" | "next" | "current";
+  }) => {
+    const selectedDate = getSelectedDate(year, month, date, state);
+    return (
+      (startDate && selectedDate.toDateString() === startDate.toDateString()) ||
+      (endDate && selectedDate.toDateString() === endDate.toDateString())
+    );
+  };
+
+  const isInRange = ({
+    date,
+    state = "current",
+  }: {
+    date: number;
+    state?: "prev" | "next" | "current";
+  }) => {
+    const selectedDate = getSelectedDate(year, month, date, state);
+    return (
+      startDate && endDate && selectedDate > startDate && selectedDate < endDate
+    );
+  };
+
+  const isRangeStart = ({
+    date,
+    state = "current",
+  }: {
+    date: number;
+    state?: "prev" | "next" | "current";
+  }) => {
+    const selectedDate = getSelectedDate(year, month, date, state);
+    return (
+      startDate &&
+      endDate &&
+      selectedDate.toDateString() === startDate.toDateString() &&
+      (prevDates.length + date) % 7 !== 0
+    );
+  };
+
+  const isRangeEnd = ({
+    date,
+    state = "current",
+  }: {
+    date: number;
+    state?: "prev" | "next" | "current";
+  }) => {
+    const selectedDate = getSelectedDate(year, month, date, state);
+    return endDate && selectedDate.toDateString() === endDate.toDateString();
+  };
+
+  return {
+    year,
+    month,
+    startDate,
+    endDate,
+    prevDates,
+    currentDates,
+    nextDates,
+    handlePrevMonth,
+    handleNextMonth,
+    handleDateClick,
+    isSelected,
+    isInRange,
+    isRangeStart,
+    isRangeEnd,
+  };
+}
+
+const getSelectedDate = (
+  year: number,
+  month: number,
+  date: number,
+  state: "prev" | "next" | "current" = "current",
+): Date => {
+  let selectedDate = new Date(year, month, date);
+  if (state === "prev") selectedDate = new Date(year, month - 1, date);
+  if (state === "next") selectedDate = new Date(year, month + 1, date);
+  return selectedDate;
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -26,23 +26,6 @@
   .filter-inactive {
     @apply border border-gray-700 bg-gray-900 text-gray-500;
   }
-
-  .custom-calendar {
-    width: 100%;
-    border: none;
-  }
-
-  .custom-calendar .react-calendar__tile--active,
-  .custom-calendar .react-calendar__tile--hover {
-    background-color: #ffa726 !important;
-    color: white !important;
-    border-radius: 50%;
-  }
-
-  .custom-calendar .selected-range {
-    background-color: rgba(255, 167, 38, 0.5) !important;
-    border-radius: 0;
-  }
 }
 
 /* 공용 버튼 */


### PR DESCRIPTION
## 제목 규칙
`feat(issue 번호) : 기능명` 형태로 작성하세요.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 기능 변경
- [x] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- `from`: Refactor/23/calendar
- `to`: develop
### 작업 내용 및 변경 사항
- 캘린더를 커스텀 훅과 캘린더 컴포넌트로 분리했습니다.
- 캘린더 `startDate`와 `endDate`가 설정 되어 있을 때 범위를 클릭하면 범위가 초기화 되고 `startDate`에 클릭한 날짜가 들어갑니다.
### 결과 이미지(화면 캡쳐해서)
![Screenshot 2025-01-08 at 11 00 06](https://github.com/user-attachments/assets/174dcbc5-4fdf-4bff-8d78-7f2651e76f64)
### Todo
- X
### 이슈 링크
- #23 
### 리뷰어 멘션하기
- 본인 username 제외하고 PR 날려주세요
@joshuayeyo @ITHPARK @Stilllee