### PR TITLE
Refactor(#48): 드롭다운의 아이템 선택 시 드롭다운이 닫히도록 개선

### DIFF
--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -2,31 +2,7 @@
 
 import React, { useState } from "react";
 import Popover from "./Popover";
-
-type Align = "LR" | "CC" | "RL" | "LL" | "RR";
-
-type DropdownItem = {
-  label: string; // 항목 텍스트
-  value?: string; // 항목 값
-  onClick?: () => void; // 항목별 클릭 핸들러
-};
-
-type DropdownProps = {
-  align?: Align; // 드롭다운 정렬 방식
-  content: DropdownItem[]; // 드롭다운 항목 배열
-  gapX?: number; // X축 간격
-  gapY?: number; // Y축 간격
-  defaultSelected?: string; // 기본 선택 항목
-  children: React.ReactNode; // 트리거 요소
-};
-
-type VerticalAlign = "bottom" | "top" | "center";
-type HorizontalAlign = "left" | "right" | "center";
-
-type Position = {
-  anchor: { vertical: VerticalAlign; horizontal: HorizontalAlign };
-  content: { vertical: VerticalAlign; horizontal: HorizontalAlign };
-};
+import { type DropdownProps, type Position } from "@/types/dropdown.type";
 
 export default function Dropdown({
   align = "RR",
@@ -40,44 +16,45 @@ export default function Dropdown({
     defaultSelected || null,
   );
 
-  const handleSelect = (label: string, onClick?: () => void) => {
+  const handleSelect = (
+    label: string,
+    value?: string,
+    onClick?: (value: string) => void,
+    closePopover?: () => void,
+  ) => {
     setSelected(label);
-    console.log(label);
-    if (onClick) onClick();
+    if (onClick && value) onClick(value);
+    if (closePopover) closePopover();
   };
 
-  const getPosition = (): Position => {
+  const getPosition = () => {
     switch (align) {
       case "LR":
         return {
           anchor: { vertical: "bottom", horizontal: "left" },
           content: { vertical: "top", horizontal: "right" },
-        };
+        } as Position;
       case "CC":
         return {
           anchor: { vertical: "bottom", horizontal: "center" },
           content: { vertical: "top", horizontal: "center" },
-        };
+        } as Position;
       case "RL":
         return {
           anchor: { vertical: "bottom", horizontal: "right" },
           content: { vertical: "top", horizontal: "left" },
-        };
+        } as Position;
       case "LL":
         return {
           anchor: { vertical: "bottom", horizontal: "left" },
           content: { vertical: "top", horizontal: "left" },
-        };
+        } as Position;
       case "RR":
+      default:
         return {
           anchor: { vertical: "bottom", horizontal: "right" },
           content: { vertical: "top", horizontal: "right" },
-        };
-      default:
-        return {
-          anchor: { vertical: "bottom", horizontal: "center" },
-          content: { vertical: "top", horizontal: "center" },
-        };
+        } as Position;
     }
   };
 
@@ -86,21 +63,25 @@ export default function Dropdown({
       gapX={gapX}
       gapY={gapY}
       position={getPosition()}
-      content={
+      content={(closePopover) => (
         <ul className='min-w-[7.25rem] cursor-pointer rounded-xl border border-gray-800 bg-gray-900'>
           {content.map((item, index) => (
             <li
               key={index}
-              className={`text-body-2-normal ${selected === item.label || selected === item.value ? "text-gray-200" : "text-gray-500"} mx-auto w-max px-[0.875rem] py-3 text-center font-semibold`}
+              className={`text-body-2-normal ${
+                selected === item.label || selected === item.value
+                  ? "text-gray-200"
+                  : "text-gray-500"
+              } mx-auto w-max px-[0.875rem] py-3 text-center font-semibold`}
               onClick={() =>
-                handleSelect(item.value ?? item.label, item.onClick)
+                handleSelect(item.label, item.value, item.onClick, closePopover)
               }
             >
               {item.label}
             </li>
           ))}
         </ul>
-      }
+      )}
     >
       {children}
     </Popover>

--- a/src/types/dropdown.type.ts
+++ b/src/types/dropdown.type.ts
@@ -1,0 +1,38 @@
+type Origin = "top" | "center" | "bottom";
+type HorizontalOrigin = "left" | "center" | "right";
+
+export type Position = {
+  anchor: { vertical: Origin; horizontal: HorizontalOrigin };
+  content: { vertical: Origin; horizontal: HorizontalOrigin };
+};
+
+export type PopoverRenderFn = (close: () => void) => React.ReactNode;
+
+export type PopoverProps = {
+  gapX?: number;
+  gapY?: number;
+  position?: Position;
+  onOpen?: () => void;
+  onClose?: () => void;
+
+  /** Popover의 내용을 함수 형태로 받을 수 있음 */
+  content: React.ReactNode | PopoverRenderFn;
+  children: React.ReactNode;
+};
+
+type Align = "LR" | "CC" | "RL" | "LL" | "RR";
+
+type DropdownItem = {
+  label: string;
+  value?: string;
+  onClick?: (value: string) => void;
+};
+
+export type DropdownProps = {
+  align?: Align;
+  content: DropdownItem[];
+  gapX?: number;
+  gapY?: number;
+  defaultSelected?: string;
+  children: React.ReactNode;
+};


### PR DESCRIPTION
## 제목 규칙
`feat(issue 번호) : 기능명` 형태로 작성하세요.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 기능 변경
- [x] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- `from`: refactor/48/dropdown
- `to`: develop
### 작업 내용 및 변경 사항
- 기존 드롭다운은 드롭다운의 아이템을 클릭해도 드롭다운이 닫히지 않았습니다. 그래서 클릭하면 닫히도록 개선했습니다.
### 결과 이미지(화면 캡쳐해서)
![Screenshot 2025-01-10 at 09 30 43](https://github.com/user-attachments/assets/37f0b6fc-eb27-4b8b-88b9-924cfd711582)

### Todo
- x
### 이슈 링크
- close #48 
### 리뷰어 멘션하기
- 본인 username 제외하고 PR 날려주세요
@joshuayeyo @ITHPARK @Stilllee