### PR TITLE
Feat(#57): 모임카드 마감일 표기 수정

### DIFF
--- a/src/components/common/card/Card.tsx
+++ b/src/components/common/card/Card.tsx
@@ -41,7 +41,7 @@ export default function Card({ card }: CardInfo) {
 
   return (
     <div
-      className='mb-6 flex flex-col rounded-[16px] bg-gray-950 p-3'
+      className='flex flex-col rounded-[16px] bg-gray-950 p-3'
       onClick={() => handleClickDetail(card.itemType, card.id)}
     >
       <div className='flex justify-between'>

--- a/src/components/common/card/Card.tsx
+++ b/src/components/common/card/Card.tsx
@@ -48,11 +48,7 @@ export default function Card({ card }: CardInfo) {
         <div className='flex gap-1.5'>
           <StatusBadge
             status={card.status}
-            recruitmentDate={
-              card.status === "모집중"
-                ? card.recruitmentPeriod.endDate
-                : new Date()
-            }
+            recruitmentDate={card.recruitmentPeriod.endDate}
           />
         </div>
 

--- a/src/components/common/card/StatusBadge.tsx
+++ b/src/components/common/card/StatusBadge.tsx
@@ -29,15 +29,11 @@ export default function StatusBadge({
               </span>
             </span>
             <span className='flex items-center justify-between gap-1.5 rounded-[6px] bg-gray-800 px-2 py-1'>
-              {deadline(recruitmentDate) == 0 ? (
-                <span className='text-caption-normal font-medium text-primary'>
-                  오늘 마감
-                </span>
-              ) : (
-                <span className='text-caption-normal font-medium text-primary'>
-                  {`마감 D-${deadline(recruitmentDate)}`}
-                </span>
-              )}
+              <span className='text-caption-normal font-medium text-primary'>
+                {deadline(recruitmentDate) == 0
+                  ? "오늘 마감"
+                  : `마감 D-${deadline(recruitmentDate)}`}
+              </span>
             </span>
           </div>
         );

--- a/src/components/common/card/StatusBadge.tsx
+++ b/src/components/common/card/StatusBadge.tsx
@@ -4,7 +4,10 @@ import Hand from "@/assets/images/icons/waving-hand.svg";
 import { type BadgeProps } from "@/types/card";
 
 //recruitmentDate = new Date() 모집중이 아닐때 오류를 피하기 위한 설정?
-export default function StatusBadge({ status, recruitmentDate }: BadgeProps) {
+export default function StatusBadge({
+  status,
+  recruitmentDate = new Date(),
+}: BadgeProps) {
   const deadline = (date: Date) => {
     let diffTime;
     if (recruitmentDate) {
@@ -26,21 +29,27 @@ export default function StatusBadge({ status, recruitmentDate }: BadgeProps) {
               </span>
             </span>
             <span className='flex items-center justify-between gap-1.5 rounded-[6px] bg-gray-800 px-2 py-1'>
-              <span className='text-caption-normal font-medium text-primary'>
-                {`마감 ${deadline(recruitmentDate)}일 전`}
-              </span>
+              {deadline(recruitmentDate) == 0 ? (
+                <span className='text-caption-normal font-medium text-primary'>
+                  오늘 마감
+                </span>
+              ) : (
+                <span className='text-caption-normal font-medium text-primary'>
+                  {`마감 D-${deadline(recruitmentDate)}`}
+                </span>
+              )}
             </span>
           </div>
         );
 
-      // case "시작전" :
-      // return(
-      //     <span className="px-2 py-1 flex justify-between items-center gap-1.5 bg-gray-800 rounded-[6px]">
-      //             <span className="text-caption-normal text-primary font-medium">
-      //                 {`마감 `}
-      //             </span>
-      //         </span>
-      // )
+      case "시작전":
+        return (
+          <span className='flex items-center justify-between gap-1.5 rounded-[6px] bg-gray-800 px-2 py-1'>
+            <span className='text-caption-normal font-medium text-gray-300'>
+              {`시작 전 `}
+            </span>
+          </span>
+        );
 
       case "진행중":
         return (

--- a/src/components/common/card/StatusBadge.tsx
+++ b/src/components/common/card/StatusBadge.tsx
@@ -26,13 +26,11 @@ export default function StatusBadge({
                 모집 중
               </span>
             </span>
-            <span className='flex items-center justify-between gap-1.5 rounded-[6px] bg-gray-800 px-2 py-1'>
+            <span className='flex items-center justify-between rounded-[6px] bg-gray-800 px-2 py-1'>
               <span className='text-caption-normal font-medium text-primary'>
-                <span className='text-caption-normal font-medium text-primary'>
-                  {deadline(recruitmentDate) == 0
-                    ? "오늘 마감"
-                    : `마감 D-${deadline(recruitmentDate)}`}
-                </span>
+                {deadline(recruitmentDate) == 0
+                  ? "오늘 마감"
+                  : `마감 D-${deadline(recruitmentDate)}`}
               </span>
             </span>
           </div>

--- a/src/components/common/card/StatusBadge.tsx
+++ b/src/components/common/card/StatusBadge.tsx
@@ -9,12 +9,10 @@ export default function StatusBadge({
   recruitmentDate = new Date(),
 }: BadgeProps) {
   const deadline = (date: Date) => {
-    let diffTime;
-    if (recruitmentDate) {
-      diffTime = +date - +new Date();
+    if (!recruitmentDate) return;
 
-      return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    }
+    const diffTime = +date - +new Date();
+    return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
   };
 
   const renderBadge = (status: string) => {
@@ -30,9 +28,11 @@ export default function StatusBadge({
             </span>
             <span className='flex items-center justify-between gap-1.5 rounded-[6px] bg-gray-800 px-2 py-1'>
               <span className='text-caption-normal font-medium text-primary'>
-                {deadline(recruitmentDate) == 0
-                  ? "오늘 마감"
-                  : `마감 D-${deadline(recruitmentDate)}`}
+                <span className='text-caption-normal font-medium text-primary'>
+                  {deadline(recruitmentDate) == 0
+                    ? "오늘 마감"
+                    : `마감 D-${deadline(recruitmentDate)}`}
+                </span>
               </span>
             </span>
           </div>

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -17,7 +17,7 @@ export interface CardInfo {
 
 export interface BadgeProps {
   status: string;
-  recruitmentDate: Date;
+  recruitmentDate?: Date;
 }
 
 export interface CardContentProps {


### PR DESCRIPTION
## 제목 규칙
`feat(issue 번호) : 기능명` 형태로 작성하세요.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 기능 변경
- [x] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- `from`: feat/57/card
- `to`: develop
### 작업 내용 및 변경 사항
- 모임카드 마감일 표기를 수정하였습니다.
- 오늘 모집 마감인 모임은 "오늘 마감"으로 표기합니다.
- 모집중에만 받는 모집 마감 날짜를 받는 타입을 옵셔널로 수정하였습니다.
- 카드의 margin-bottom을 제거하였습니다.
### 결과 이미지(화면 캡쳐해서)
표기 수정|margin-bottom 제거
---|---
![image](https://github.com/user-attachments/assets/e7cada81-3cd6-4136-8685-ff3808f22017)|![image](https://github.com/user-attachments/assets/b2371725-2670-4e2e-9764-e6cf441ce210)


### Todo

### 이슈 링크
- #57 
### 리뷰어 멘션하기
- 본인 username 제외하고 PR 날려주세요
@joshuayeyo @wjsdncl @Stilllee 