### PR TITLE
Fix(#97): 모달을 열었을 때 배경이 늘어나는 문제 해결

### DIFF
--- a/src/components/common/modals/Modal.tsx
+++ b/src/components/common/modals/Modal.tsx
@@ -18,9 +18,24 @@ export default function Modal({
 
   useEffect(() => {
     if (isOpen) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "auto";
+      const preventScroll = (e: Event) => {
+        e.preventDefault();
+      };
+
+      const preventTouchMove = (e: TouchEvent) => {
+        e.preventDefault();
+      };
+
+      window.addEventListener("wheel", preventScroll, { passive: false });
+      window.addEventListener("touchmove", preventTouchMove, {
+        passive: false,
+      });
+
+      return () => {
+        window.removeEventListener("wheel", preventScroll);
+        window.removeEventListener("touchmove", preventTouchMove);
+        document.body.style.paddingRight = "";
+      };
     }
   }, [isOpen]);
 
@@ -34,7 +49,6 @@ export default function Modal({
 
     history.pushState(null, "", location.href);
     window.addEventListener("popstate", preventGoBack);
-
     return () => window.removeEventListener("popstate", preventGoBack);
   }, [isOpen, close]);
 
@@ -58,7 +72,6 @@ export default function Modal({
           <div className='flex max-h-full min-h-[1.3125rem] w-full items-center justify-center'>
             <div className='h-[0.3125rem] w-16 rounded-full bg-black tablet:hidden' />
           </div>
-
           {(title || hasCloseBtn) && (
             <div
               className={`flex max-h-14 min-h-8 w-full max-w-[23rem] items-center px-5 py-1 ${title ? "justify-between" : "justify-end"}`}
@@ -75,7 +88,6 @@ export default function Modal({
               )}
             </div>
           )}
-
           <div className='w-full grow pb-4'>{children}</div>
         </div>
       </div>


### PR DESCRIPTION
## 제목 규칙
`feat(issue 번호) : 기능명` 형태로 작성하세요.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 기능 변경
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- `from`: fix/97/modal scroll
- `to`: develop
### 작업 내용 및 변경 사항
- 모달을 열어도 스크롤이 없어지지 않도록해서 배경이 안움직이게 했습니다.
- 여전히 스크롤은 안되지만 스크롤바를 직접 클릭해서 움직이면 스크롤이 가능합니다.
### 결과 이미지(화면 캡쳐해서)
![Screenshot 2025-01-20 at 17 02 44](https://github.com/user-attachments/assets/5d42713e-a53e-4665-af37-b2d45e4be397)
### Todo
- [ ] 추가로 작업해야 할 사항에 대해 알려주세요
### 이슈 링크
- close #97 
### 리뷰어 멘션하기
- 본인 username 제외하고 PR 날려주세요
@joshuayeyo @ITHPARK @Stilllee