### PR TITLE
Fix(#118): 유저페이지의 목록이 갑자기 안 보이는 문제

### DIFF
--- a/src/components/user-page/MeetingList.tsx
+++ b/src/components/user-page/MeetingList.tsx
@@ -108,9 +108,10 @@ export const MeetingList = ({
     <section aria-label={`${tab} 목록`}>
       <ul className='grid flex-col gap-y-6 desktop:grid-cols-2 desktop:gap-x-5'>
         {data.pages.map((page, pageIndex) =>
-          page.items.map((item, itemIndex) =>
-            renderItem(item, pageIndex * 10 + itemIndex),
-          ),
+          page.items.map((item, itemIndex) => {
+            const globalIndex = pageIndex * page.items.length + itemIndex;
+            return renderItem(item, globalIndex);
+          }),
         )}
         {isFetchingNextPage && (
           <li className='col-span-full flex justify-center py-4 text-white'>

--- a/src/components/user-page/MeetingList.tsx
+++ b/src/components/user-page/MeetingList.tsx
@@ -124,7 +124,7 @@ export const MeetingList = ({
 
 // 타입 가드 함수
 function isMeetingCard(item: CardProps | ReviewInfo): item is CardProps {
-  return "meetupId" in item && "status" in item;
+  return "meetupId" in item && "meetupStatus" in item;
 }
 
 function isReviewInfo(item: CardProps | ReviewInfo): item is ReviewInfo {

--- a/src/constants/pagination.ts
+++ b/src/constants/pagination.ts
@@ -1,0 +1,1 @@
+export const PAGE_SIZE = 10; // 무한스크롤 페이지 당 아이템 개수

--- a/src/hooks/useInfiniteMeetings.ts
+++ b/src/hooks/useInfiniteMeetings.ts
@@ -48,7 +48,6 @@ export const useInfiniteMeetings = ({
     queryFn: async ({ pageParam = 1 }) => {
       const type = studyType === "study" ? "STUDY" : "TUTORING";
       const page = pageParam - 1;
-      console.log(`[무한스크롤] ${tab} 데이터 요청 - 페이지: ${page}`);
 
       try {
         switch (tab) {
@@ -73,11 +72,6 @@ export const useInfiniteMeetings = ({
             );
             const result =
               (await response.json()) as ApiResponse<CreatedMeetup>;
-            console.log("[만든 모임 API 응답]", {
-              data: result.data,
-              isLast: result.additionalData.isLast,
-              nextPage: result.additionalData.nextPage,
-            });
             return transformPageResponse(result, (item) =>
               mapCreatedMeetupToCard(item, type),
             );

--- a/src/hooks/useInfiniteMeetings.ts
+++ b/src/hooks/useInfiniteMeetings.ts
@@ -47,6 +47,8 @@ export const useInfiniteMeetings = ({
     queryKey: ["meetings", tab, studyType, reviewTab, userId],
     queryFn: async ({ pageParam = 1 }) => {
       const type = studyType === "study" ? "STUDY" : "TUTORING";
+      const page = pageParam - 1;
+      console.log(`[무한스크롤] ${tab} 데이터 요청 - 페이지: ${page}`);
 
       try {
         switch (tab) {
@@ -55,7 +57,7 @@ export const useInfiniteMeetings = ({
               userId,
               type,
               token,
-              pageParam - 1,
+              page,
             );
             const result =
               (await response.json()) as ApiResponse<ParticipatingMeetup>;
@@ -67,10 +69,15 @@ export const useInfiniteMeetings = ({
               userId,
               type,
               token,
-              pageParam - 1,
+              page,
             );
             const result =
               (await response.json()) as ApiResponse<CreatedMeetup>;
+            console.log("[만든 모임 API 응답]", {
+              data: result.data,
+              isLast: result.additionalData.isLast,
+              nextPage: result.additionalData.nextPage,
+            });
             return transformPageResponse(result, (item) =>
               mapCreatedMeetupToCard(item, type),
             );
@@ -83,7 +90,7 @@ export const useInfiniteMeetings = ({
               type,
               status,
               token,
-              pageParam - 1,
+              page,
             );
 
             if (status === "eligible") {
@@ -106,7 +113,7 @@ export const useInfiniteMeetings = ({
             const response = await userContentApi.getReceived(
               userId,
               token,
-              pageParam - 1,
+              page,
             );
             const result =
               (await response.json()) as ApiResponse<WrittenReview>;
@@ -126,9 +133,12 @@ export const useInfiniteMeetings = ({
         throw error;
       }
     },
-    getNextPageParam: (lastPage: PageResponse<CardProps | ReviewInfo>) => {
-      if (!lastPage.hasNextPage || lastPage.nextPage === -1) return undefined;
-      return lastPage.nextPage;
+    getNextPageParam: (
+      lastPage: PageResponse<CardProps | ReviewInfo>,
+      pages,
+    ) => {
+      if (!lastPage.hasNextPage) return undefined;
+      return pages.length + 1;
     },
     initialPageParam: 1,
     refetchOnMount: false,

--- a/src/hooks/useInfiniteMeetings.ts
+++ b/src/hooks/useInfiniteMeetings.ts
@@ -51,6 +51,9 @@ export const useInfiniteMeetings = ({
       try {
         switch (tab) {
           case "myMeeting": {
+            console.log(
+              `[참여중인 모임 요청] userId: ${userId}, type: ${type}, page: ${pageParam - 1}`,
+            );
             const response = await userContentApi.getParticipating(
               userId,
               type,
@@ -59,10 +62,14 @@ export const useInfiniteMeetings = ({
             );
             const result =
               (await response.json()) as ApiResponse<ParticipatingMeetup>;
+            console.log("[참여중인 모임 응답]", result);
             return transformPageResponse(result, mapParticipatingMeetupToCard);
           }
 
           case "createdMeeting": {
+            console.log(
+              `[만든 모임 요청] userId: ${userId}, type: ${type}, page: ${pageParam - 1}`,
+            );
             const response = await userContentApi.getCreated(
               userId,
               type,
@@ -71,6 +78,7 @@ export const useInfiniteMeetings = ({
             );
             const result =
               (await response.json()) as ApiResponse<CreatedMeetup>;
+            console.log("[만든 모임 응답]", result);
             return transformPageResponse(result, (item) =>
               mapCreatedMeetupToCard(item, type),
             );
@@ -78,6 +86,9 @@ export const useInfiniteMeetings = ({
 
           case "myReview": {
             const status = reviewTab === "toWrite" ? "eligible" : "written";
+            console.log(
+              `[리뷰 요청] userId: ${userId}, type: ${type}, status: ${status}, page: ${pageParam - 1}`,
+            );
             const response = await userContentApi.getWritten(
               userId,
               type,
@@ -89,12 +100,14 @@ export const useInfiniteMeetings = ({
             if (status === "eligible") {
               const result =
                 (await response.json()) as ApiResponse<EligibleReview>;
+              console.log("[작성 가능한 리뷰 응답]", result);
               return transformPageResponse(result, (item) =>
                 mapEligibleReviewToCard(item, type),
               );
             } else {
               const result =
                 (await response.json()) as ApiResponse<WrittenReview>;
+              console.log("[작성한 리뷰 응답]", result);
               return transformPageResponse(result, (item) => ({
                 ...mapWrittenReviewToReviewInfo(item),
                 eventType: type.toLowerCase(),
@@ -103,6 +116,9 @@ export const useInfiniteMeetings = ({
           }
 
           case "classReview": {
+            console.log(
+              `[수강평 요청] userId: ${userId}, page: ${pageParam - 1}`,
+            );
             const response = await userContentApi.getReceived(
               userId,
               token,
@@ -110,6 +126,7 @@ export const useInfiniteMeetings = ({
             );
             const result =
               (await response.json()) as ApiResponse<WrittenReview>;
+            console.log("[수강평 응답]", result);
             return transformPageResponse(result, (item) => ({
               ...mapWrittenReviewToReviewInfo(item),
               eventType: "tutoring",
@@ -127,8 +144,8 @@ export const useInfiniteMeetings = ({
       }
     },
     getNextPageParam: (lastPage: PageResponse<CardProps | ReviewInfo>) => {
-      if (!lastPage.hasNextPage) return undefined;
-      return lastPage.items.length > 0 ? lastPage.items.length + 1 : undefined;
+      if (!lastPage.hasNextPage || lastPage.nextPage === -1) return undefined;
+      return lastPage.nextPage;
     },
     initialPageParam: 1,
     refetchOnMount: false,

--- a/src/hooks/useInfiniteMeetings.ts
+++ b/src/hooks/useInfiniteMeetings.ts
@@ -51,9 +51,6 @@ export const useInfiniteMeetings = ({
       try {
         switch (tab) {
           case "myMeeting": {
-            console.log(
-              `[참여중인 모임 요청] userId: ${userId}, type: ${type}, page: ${pageParam - 1}`,
-            );
             const response = await userContentApi.getParticipating(
               userId,
               type,
@@ -62,14 +59,10 @@ export const useInfiniteMeetings = ({
             );
             const result =
               (await response.json()) as ApiResponse<ParticipatingMeetup>;
-            console.log("[참여중인 모임 응답]", result);
             return transformPageResponse(result, mapParticipatingMeetupToCard);
           }
 
           case "createdMeeting": {
-            console.log(
-              `[만든 모임 요청] userId: ${userId}, type: ${type}, page: ${pageParam - 1}`,
-            );
             const response = await userContentApi.getCreated(
               userId,
               type,
@@ -78,7 +71,6 @@ export const useInfiniteMeetings = ({
             );
             const result =
               (await response.json()) as ApiResponse<CreatedMeetup>;
-            console.log("[만든 모임 응답]", result);
             return transformPageResponse(result, (item) =>
               mapCreatedMeetupToCard(item, type),
             );
@@ -86,9 +78,6 @@ export const useInfiniteMeetings = ({
 
           case "myReview": {
             const status = reviewTab === "toWrite" ? "eligible" : "written";
-            console.log(
-              `[리뷰 요청] userId: ${userId}, type: ${type}, status: ${status}, page: ${pageParam - 1}`,
-            );
             const response = await userContentApi.getWritten(
               userId,
               type,
@@ -100,14 +89,12 @@ export const useInfiniteMeetings = ({
             if (status === "eligible") {
               const result =
                 (await response.json()) as ApiResponse<EligibleReview>;
-              console.log("[작성 가능한 리뷰 응답]", result);
               return transformPageResponse(result, (item) =>
                 mapEligibleReviewToCard(item, type),
               );
             } else {
               const result =
                 (await response.json()) as ApiResponse<WrittenReview>;
-              console.log("[작성한 리뷰 응답]", result);
               return transformPageResponse(result, (item) => ({
                 ...mapWrittenReviewToReviewInfo(item),
                 eventType: type.toLowerCase(),
@@ -116,9 +103,6 @@ export const useInfiniteMeetings = ({
           }
 
           case "classReview": {
-            console.log(
-              `[수강평 요청] userId: ${userId}, page: ${pageParam - 1}`,
-            );
             const response = await userContentApi.getReceived(
               userId,
               token,
@@ -126,7 +110,6 @@ export const useInfiniteMeetings = ({
             );
             const result =
               (await response.json()) as ApiResponse<WrittenReview>;
-            console.log("[수강평 응답]", result);
             return transformPageResponse(result, (item) => ({
               ...mapWrittenReviewToReviewInfo(item),
               eventType: "tutoring",

--- a/src/lib/user/userContent.ts
+++ b/src/lib/user/userContent.ts
@@ -1,6 +1,5 @@
 import { fetcher } from "./clientFetch";
-
-const PAGE_SIZE = 10;
+import { PAGE_SIZE } from "@/constants/pagination";
 
 export const userContentApi = {
   getReceived: (userId: string, token: string, page: number) =>

--- a/src/types/user-page/index.ts
+++ b/src/types/user-page/index.ts
@@ -85,6 +85,7 @@ export interface EmptyStateProps {
 export interface PageResponse<T> {
   items: T[];
   hasNextPage: boolean;
+  nextPage: number;
 }
 
 export interface FetchConfig {
@@ -127,7 +128,7 @@ export interface CreatedMeetup extends BaseMeetup {
 }
 
 export interface EligibleReview extends BaseMeetup {
-  status: MeetingStatus;
+  status: MeetingStatus; // 항상 status 사용
   maxParticipants: number;
   minParticipants: number;
   participantsCount: number;
@@ -145,5 +146,6 @@ export interface WrittenReview {
   content: string;
   meetingEndDate: string;
   thumbnail?: string;
+  reviewThumbnail?: string; // 수강평 API 응답용
   reviewDate: string;
 }

--- a/src/utils/userContentMapper.ts
+++ b/src/utils/userContentMapper.ts
@@ -105,18 +105,8 @@ export const mapWrittenReviewToReviewInfo = (
 export const transformPageResponse = <T, U>(
   response: ApiResponse<T>,
   mapper: (item: T) => U,
-): PageResponse<U> => {
-  console.log("[무한스크롤] API 응답 전체", response);
-  console.log("[무한스크롤] API 응답 데이터", {
-    totalElements: response.data.length,
-    isLast: response.additionalData.isLast,
-    nextPage: response.additionalData.nextPage,
-    data: response.data,
-  });
-
-  return {
-    items: response.data.map(mapper),
-    hasNextPage: !response.additionalData.isLast,
-    nextPage: response.additionalData.nextPage,
-  };
-};
+): PageResponse<U> => ({
+  items: response.data.map(mapper),
+  hasNextPage: !response.additionalData.isLast,
+  nextPage: response.additionalData.nextPage,
+});

--- a/src/utils/userContentMapper.ts
+++ b/src/utils/userContentMapper.ts
@@ -105,8 +105,18 @@ export const mapWrittenReviewToReviewInfo = (
 export const transformPageResponse = <T, U>(
   response: ApiResponse<T>,
   mapper: (item: T) => U,
-): PageResponse<U> => ({
-  items: response.data.map(mapper),
-  hasNextPage: !response.additionalData.isLast,
-  nextPage: response.additionalData.nextPage,
-});
+): PageResponse<U> => {
+  console.log("[무한스크롤] API 응답 전체", response);
+  console.log("[무한스크롤] API 응답 데이터", {
+    totalElements: response.data.length,
+    isLast: response.additionalData.isLast,
+    nextPage: response.additionalData.nextPage,
+    data: response.data,
+  });
+
+  return {
+    items: response.data.map(mapper),
+    hasNextPage: !response.additionalData.isLast,
+    nextPage: response.additionalData.nextPage,
+  };
+};

--- a/src/utils/userContentMapper.ts
+++ b/src/utils/userContentMapper.ts
@@ -108,4 +108,5 @@ export const transformPageResponse = <T, U>(
 ): PageResponse<U> => ({
   items: response.data.map(mapper),
   hasNextPage: !response.additionalData.isLast,
+  nextPage: response.additionalData.nextPage,
 });

--- a/src/utils/userPage.ts
+++ b/src/utils/userPage.ts
@@ -1,3 +1,4 @@
+import { PAGE_SIZE } from "@/constants/pagination";
 import useCookie from "@/hooks/auths/useTokenState";
 import { fetcher } from "@/lib/user/clientFetch";
 import { type CardProps } from "@/types/card";
@@ -13,8 +14,6 @@ import {
   type EligibleReview,
   type WrittenReview,
 } from "@/types/user-page";
-
-const PAGE_SIZE = 10;
 
 // API 응답을 CardProps로 변환하는 함수
 const mapParticipatingMeetupToCard = (

--- a/src/utils/userPage.ts
+++ b/src/utils/userPage.ts
@@ -140,6 +140,7 @@ export const fetchItems = async ({
       return {
         items: result.data.map(mapParticipatingMeetupToCard),
         hasNextPage: !result.additionalData.isLast,
+        nextPage: result.additionalData.nextPage,
       };
     } catch (error) {
       console.error("Error fetching participating meetups:", error);
@@ -168,6 +169,7 @@ export const fetchItems = async ({
           mapCreatedMeetupToCard(meetup, type),
         ),
         hasNextPage: !result.additionalData.isLast,
+        nextPage: result.additionalData.nextPage,
       };
     } catch (error) {
       console.error("Error fetching created meetups:", error);
@@ -204,6 +206,7 @@ export const fetchItems = async ({
               },
         ),
         hasNextPage: !result.additionalData.isLast,
+        nextPage: result.additionalData.nextPage,
       };
     } catch (error) {
       console.error("Error fetching reviews:", error);
@@ -214,37 +217,25 @@ export const fetchItems = async ({
   // 수강평 탭일 경우 실제 API 호출
   if (tab === "classReview") {
     try {
-      const url = `/user/${userId}/reviews/received?page=${page - 1}&limit=${PAGE_SIZE}`;
-      console.log("[수강평 API 요청]", {
-        url,
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-
-      const response = await fetcher(url, token, { auth: true });
-
-      console.log("[수강평 API 응답 상태]", {
-        status: response.status,
-        statusText: response.statusText,
-        headers: Object.fromEntries(response.headers.entries()),
-      });
+      const response = await fetcher(
+        `/user/${userId}/reviews/received?page=${page - 1}&limit=${PAGE_SIZE}`,
+        token,
+        { auth: true },
+      );
 
       if (!response.ok) {
-        const errorText = await response.text();
-        console.error("[수강평 API 에러]", errorText);
         throw new Error("Failed to fetch class reviews");
       }
 
       const result: ApiResponse<WrittenReview> = await response.json();
-      console.log("[수강평 API 응답 데이터]", result);
 
       return {
         items: result.data.map((item) => ({
-          ...mapWrittenReviewToReviewInfo(item as WrittenReview),
+          ...mapWrittenReviewToReviewInfo(item),
           eventType: "tutoring",
         })),
         hasNextPage: !result.additionalData.isLast,
+        nextPage: result.additionalData.nextPage,
       };
     } catch (error) {
       console.error("Error fetching class reviews:", error);


### PR DESCRIPTION
## 제목 규칙
`feat(issue 번호) : 기능명` 형태로 작성하세요.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 기능 변경
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- `from`: fix/118/user-page
- `to`: Develop
### 작업 내용 및 변경 사항
- 공통 카드 컴포넌트 변경으로 인해 기존의 유저페이지의 목록들이 보여지지 않는 문제 해결을 위해 매핑함수과 관련 타입을 수정했습니다.

### 결과 이미지(화면 캡쳐해서)
https://github.com/user-attachments/assets/e1c301b8-8709-4101-aaa0-6f7385944d49

### Todo
- [ ] 리뷰 컴포넌틑 '리뷰 작성' 스타일 깨지는 이슈 확인 필요
### 이슈 링크
- #118 
### 리뷰어 멘션하기
- 본인 username 제외하고 PR 날려주세요
@joshuayeyo @ITHPARK @wjsdncl
