### PR TITLE
Feat(#125): 모임 생성 시 과외 모임 타입 추가 및 모임 수정 기능 추가

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,15 @@ const nextConfig = {
     });
     return config;
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "fesi6.s3.dualstack.ap-southeast-2.amazonaws.com",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/create/[id]/page.tsx
+++ b/src/app/create/[id]/page.tsx
@@ -1,0 +1,41 @@
+"use server";
+
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query";
+import CloseButton from "@/components/create/CloseButton";
+import CreateForm from "@/components/create/CreateForm";
+import { fetchMeetupData } from "@/lib/meetDetail/meetDetailApi";
+
+export default async function CreatePage({
+  params,
+}: {
+  params: { id: number };
+}) {
+  const queryClient = new QueryClient();
+  const { id } = params;
+  await queryClient.prefetchQuery({
+    queryKey: ["meetup", id],
+    queryFn: () => fetchMeetupData(id),
+  });
+
+  return (
+    <div className='mx-auto flex size-full grow flex-col desktop:max-w-[1200px]'>
+      <div className='absolute inset-0 size-full bg-gray-950' />
+
+      <section className='z-10 flex h-14 items-center justify-between border-b border-gray-900 px-5 py-2.5 desktop:px-5'>
+        <p className='w-full grow text-body-1-normal font-semibold text-gray-200'>
+          모임 수정하기
+        </p>
+
+        <CloseButton />
+      </section>
+
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <CreateForm id={id} />
+      </HydrationBoundary>
+    </div>
+  );
+}

--- a/src/components/common/inputs/ImageUpload.tsx
+++ b/src/components/common/inputs/ImageUpload.tsx
@@ -1,21 +1,14 @@
-import { useEffect } from "react";
+import { useRef } from "react";
 import UploadIcon from "@/assets/images/icons/camera.svg";
 import { useUploadImage } from "@/hooks/inputs/images/useUploadImage";
 
-type ImageuploadProps = {
+type ImageUploadProps = {
   label: string;
-  onImageChange?: (file: File | null) => void;
 };
 
-const CommonImageInput = ({ label, onImageChange }: ImageuploadProps) => {
-  const { image, previewUrl, handleImageUpload, handleImageDelete } =
-    useUploadImage();
-
-  useEffect(() => {
-    if (onImageChange && image) {
-      onImageChange(image);
-    }
-  }, [image, onImageChange]);
+const CommonImageInput = ({ label }: ImageUploadProps) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { previewUrl, handleImageUpload, handleImageDelete } = useUploadImage();
 
   return (
     <div className='flex flex-col gap-[12px]'>
@@ -30,7 +23,7 @@ const CommonImageInput = ({ label, onImageChange }: ImageuploadProps) => {
       <button
         type='button'
         className='group relative flex h-[120px] w-[120px] items-center justify-center rounded-[12px] border border-gray-800 bg-gray-900'
-        onClick={() => document.getElementById("fileInput")?.click()}
+        onClick={() => fileInputRef.current?.click()}
       >
         {/* 이미지 미리보기 */}
         {previewUrl ? (
@@ -45,7 +38,6 @@ const CommonImageInput = ({ label, onImageChange }: ImageuploadProps) => {
               className='absolute left-12 top-12 z-10 hidden h-[24px] w-[24px] items-center justify-center rounded-[7px] bg-[#28292E] p-1 text-center text-label-normal font-semibold text-[#C4C4C4] group-hover:block'
               onClick={async (data) => {
                 await handleImageDelete(data);
-                if (onImageChange) onImageChange(null);
               }}
             >
               X
@@ -60,6 +52,7 @@ const CommonImageInput = ({ label, onImageChange }: ImageuploadProps) => {
       <input
         type='file'
         id='fileInput'
+        ref={fileInputRef}
         accept='image/*'
         onChange={handleImageUpload}
         className='hidden'

--- a/src/components/common/inputs/ImageUpload.tsx
+++ b/src/components/common/inputs/ImageUpload.tsx
@@ -53,7 +53,7 @@ const CommonImageInput = ({ label, onImageChange }: ImageuploadProps) => {
           </div>
         ) : (
           <div>
-            <UploadIcon />
+            <UploadIcon className='size-10 text-gray-600' />
           </div>
         )}
       </button>

--- a/src/components/create/CreateForm.tsx
+++ b/src/components/create/CreateForm.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { FormProvider } from "react-hook-form";
-import FormSectionLeft from "./FormSectionLeft";
-import FormSectionRight from "./FormSectionRight";
+import MeetupFormLeft from "./MeetupFormLeft";
+import MeetupFormRight from "./MeetupFormRight";
 import { useMeetupForm } from "@/hooks/forms/useMeetupForm";
 
 export default function CreateForm({ id }: { id?: number }) {
@@ -25,7 +25,7 @@ export default function CreateForm({ id }: { id?: number }) {
         onSubmit={methods.handleSubmit(onSubmit)}
         className='z-10 mx-4 my-6 flex flex-col gap-10 desktop:my-8 desktop:flex-row desktop:gap-9'
       >
-        <FormSectionLeft
+        <MeetupFormLeft
           initImage={meetupData?.thumbnail}
           control={control}
           watch={watch}
@@ -34,7 +34,7 @@ export default function CreateForm({ id }: { id?: number }) {
           isEdit={isEdit}
           setRemovedInitImage={setRemovedInitImage}
         />
-        <FormSectionRight
+        <MeetupFormRight
           watch={watch}
           setValue={setValue}
           control={control}

--- a/src/components/create/CreateForm.tsx
+++ b/src/components/create/CreateForm.tsx
@@ -1,104 +1,38 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
-import { FormProvider, type SubmitHandler, useForm } from "react-hook-form";
-import { useShallow } from "zustand/shallow";
+import { FormProvider } from "react-hook-form";
 import FormSectionLeft from "./FormSectionLeft";
 import FormSectionRight from "./FormSectionRight";
-import { FailModal, SuccessModal } from "./modals/ResultInfoModal";
-import useCookie from "@/hooks/auths/useTokenState";
-import { createMeetup } from "@/lib/main/meetup.api";
-import { getUserProfile } from "@/lib/user/getUserProfile";
-import useUserStore from "@/store/auth/useUserStore";
-import type { MeetupFormType } from "@/types/meetup.type";
-import modal from "@/utils/modalController";
+import { useMeetupForm } from "@/hooks/forms/useMeetupForm";
 
-export default function CreateForm() {
-  const methods = useForm<MeetupFormType>({
-    defaultValues: {
-      title: "",
-      meetingType: "STUDY",
-      location: "",
-      content: "",
-      recruitmentStartDate: new Date(),
-      recruitmentEndDate: null,
-      meetingStartDate: null,
-      meetingEndDate: null,
-      minParticipants: 2,
-      maxParticipants: 10,
-      isOnline: false,
-    },
-    mode: "onChange",
-  });
-  const { control, handleSubmit, watch, setValue } = methods;
-  const [image, setImage] = useState<File | null>(null);
-  const queryClient = useQueryClient();
-  const userId = useUserStore(useShallow((state) => state.user?.userId));
-  const accessToken = useCookie("accessToken");
-  const useInfo = useQuery({
-    queryKey: ["userInfo"],
-    queryFn: () => getUserProfile(userId!.toString(), accessToken!),
-    retry: 1,
-  });
-
-  const createMeetupMutation = useMutation({
-    mutationFn: createMeetup,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    onSuccess: (data: any) => {
-      queryClient.invalidateQueries({ queryKey: ["meetup"] });
-      modal.open(({ close }) => <SuccessModal data={data} close={close} />, {
-        hasCloseBtn: false,
-        isBottom: false,
-        disableOverlayClick: true,
-      });
-    },
-    onError: () => {
-      modal.open(({ close }) => <FailModal close={close} />, {
-        hasCloseBtn: false,
-        isBottom: false,
-      });
-    },
-  });
-
-  const onSubmit: SubmitHandler<MeetupFormType> = async (data) => {
-    try {
-      const formData = new FormData();
-      const jsonBlob = new Blob([JSON.stringify(data)], {
-        type: "application/json",
-      });
-      formData.append("request", jsonBlob);
-
-      if (image) {
-        formData.append("image", image);
-      }
-
-      await createMeetupMutation.mutateAsync(formData);
-    } catch (error) {
-      console.error("Error creating meetup:", error);
-    }
-  };
-
-  const isSubmitDisabled =
-    watch("title") === "" ||
-    watch("content") === "" ||
-    watch("recruitmentEndDate") === null ||
-    watch("meetingStartDate") === null ||
-    watch("meetingEndDate") === null ||
-    (watch("isOnline") === false && watch("location") === null);
+export default function CreateForm({ id }: { id?: number }) {
+  const {
+    methods,
+    onSubmit,
+    isSubmitDisabled,
+    meetupData,
+    userInfo,
+    control,
+    watch,
+    setValue,
+    isEdit,
+    setRemovedInitImage,
+  } = useMeetupForm(id);
 
   return (
     <FormProvider {...methods}>
       <form
-        onSubmit={handleSubmit(onSubmit)}
+        onSubmit={methods.handleSubmit(onSubmit)}
         className='z-10 mx-4 my-6 flex flex-col gap-10 desktop:my-8 desktop:flex-row desktop:gap-9'
       >
         <FormSectionLeft
-          setImage={setImage}
+          initImage={meetupData?.thumbnail}
           control={control}
           watch={watch}
           setValue={setValue}
-          isTutor={useInfo.data?.qualificationStatus === "QUALIFIED"}
+          isTutor={userInfo.data?.qualificationStatus === "QUALIFIED"}
+          isEdit={isEdit}
+          setRemovedInitImage={setRemovedInitImage}
         />
         <FormSectionRight
           watch={watch}
@@ -106,6 +40,7 @@ export default function CreateForm() {
           control={control}
           methods={methods}
           isSubmitDisabled={isSubmitDisabled}
+          isEdit={isEdit}
         />
       </form>
     </FormProvider>

--- a/src/components/create/CreateForm.tsx
+++ b/src/components/create/CreateForm.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { FormProvider, type SubmitHandler, useForm } from "react-hook-form";
+import { useShallow } from "zustand/shallow";
 import FormSectionLeft from "./FormSectionLeft";
 import FormSectionRight from "./FormSectionRight";
 import { FailModal, SuccessModal } from "./modals/ResultInfoModal";
+import useCookie from "@/hooks/auths/useTokenState";
 import { createMeetup } from "@/lib/main/meetup.api";
+import { getUserProfile } from "@/lib/user/getUserProfile";
+import useUserStore from "@/store/auth/useUserStore";
 import type { MeetupFormType } from "@/types/meetup.type";
 import modal from "@/utils/modalController";
 
@@ -30,6 +34,13 @@ export default function CreateForm() {
   const { control, handleSubmit, watch, setValue } = methods;
   const [image, setImage] = useState<File | null>(null);
   const queryClient = useQueryClient();
+  const userId = useUserStore(useShallow((state) => state.user?.userId));
+  const accessToken = useCookie("accessToken");
+  const useInfo = useQuery({
+    queryKey: ["userInfo"],
+    queryFn: () => getUserProfile(userId!.toString(), accessToken!),
+    retry: 1,
+  });
 
   const createMeetupMutation = useMutation({
     mutationFn: createMeetup,
@@ -87,6 +98,7 @@ export default function CreateForm() {
           control={control}
           watch={watch}
           setValue={setValue}
+          isTutor={useInfo.data?.qualificationStatus === "QUALIFIED"}
         />
         <FormSectionRight
           watch={watch}

--- a/src/components/create/FormSectionLeft.tsx
+++ b/src/components/create/FormSectionLeft.tsx
@@ -36,6 +36,8 @@ export default function FormSectionLeft({
   useEffect(() => {
     if (isOnline) {
       setValue("location", null);
+    } else {
+      if (watch("location") === null) setValue("location", "");
     }
   }, [isOnline, setValue]);
 
@@ -65,7 +67,7 @@ export default function FormSectionLeft({
       />
 
       <div
-        className={`relative h-fit w-full overflow-hidden duration-500 ease-in-out ${isOnline ? "max-h-0" : "max-h-screen"}`}
+        className={`relative h-fit w-full overflow-hidden transition-all duration-500 ${isOnline ? "max-h-0" : "max-h-screen"}`}
       >
         <CommonSelectBox
           required={!isOnline}

--- a/src/components/create/FormSectionLeft.tsx
+++ b/src/components/create/FormSectionLeft.tsx
@@ -6,8 +6,9 @@ import {
 } from "react-hook-form";
 import CommonImageInput from "../common/inputs/ImageUpload";
 import CommonSelectBox from "../common/inputs/SelectBox";
-import CommonTextArea from "../common/inputs/TextArea";
 import CommonTextInput from "../common/inputs/TextInput";
+import { FormatTypeSelection } from "./inputs/FormatTypeSelection";
+import MeetingTypeSelection from "./inputs/MeetingTypeSelection";
 import LocationIcon from "@/assets/images/icons/location.svg";
 import { type MeetupFormType } from "@/types/meetup.type";
 
@@ -16,11 +17,13 @@ export default function FormSectionLeft({
   control,
   watch,
   setValue,
+  isTutor = false,
 }: {
   setImage: (image: File | null) => void;
   control: Control<MeetupFormType>;
   watch: UseFormWatch<MeetupFormType>;
   setValue: UseFormSetValue<MeetupFormType>;
+  isTutor?: boolean;
 }) {
   const isOnline = watch("isOnline");
 
@@ -32,6 +35,12 @@ export default function FormSectionLeft({
 
   return (
     <section className='flex flex-1 flex-col gap-10'>
+      <MeetingTypeSelection
+        watch={watch}
+        setValue={setValue}
+        isTutor={isTutor}
+      />
+
       <CommonTextInput
         required={true}
         name='title'
@@ -41,8 +50,11 @@ export default function FormSectionLeft({
           required: "제목을 입력해주세요.",
         }}
       />
+
+      <FormatTypeSelection watch={watch} setValue={setValue} />
+
       <div
-        className={`relative h-fit w-full overflow-hidden transition-[max-height] duration-500 ease-in-out ${isOnline ? "max-h-0" : "max-h-screen"}`}
+        className={`relative h-fit w-full overflow-hidden duration-500 ease-in-out ${isOnline ? "max-h-0" : "max-h-screen"}`}
       >
         <CommonSelectBox
           required={!isOnline}
@@ -71,17 +83,6 @@ export default function FormSectionLeft({
       <CommonImageInput
         label='이미지'
         onImageChange={(image: File | null) => setImage(image)}
-      />
-
-      <CommonTextArea
-        required={true}
-        name='content'
-        label='본문'
-        control={control}
-        rules={{
-          required: "내용을 입력해주세요.",
-        }}
-        className='h-40 max-h-40 resize-none bg-gray-950'
       />
     </section>
   );

--- a/src/components/create/FormSectionLeft.tsx
+++ b/src/components/create/FormSectionLeft.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import Image from "next/image";
+import { useEffect, useState } from "react";
 import {
   type UseFormWatch,
   type Control,
@@ -13,19 +14,24 @@ import LocationIcon from "@/assets/images/icons/location.svg";
 import { type MeetupFormType } from "@/types/meetup.type";
 
 export default function FormSectionLeft({
-  setImage,
+  initImage,
   control,
   watch,
   setValue,
   isTutor = false,
+  isEdit = false,
+  setRemovedInitImage,
 }: {
-  setImage: (image: File | null) => void;
+  initImage?: string;
   control: Control<MeetupFormType>;
   watch: UseFormWatch<MeetupFormType>;
   setValue: UseFormSetValue<MeetupFormType>;
   isTutor?: boolean;
+  isEdit?: boolean;
+  setRemovedInitImage?: (value: boolean) => void;
 }) {
   const isOnline = watch("isOnline");
+  const [hasInitImage, setHasInitImage] = useState(!!initImage);
 
   useEffect(() => {
     if (isOnline) {
@@ -39,6 +45,7 @@ export default function FormSectionLeft({
         watch={watch}
         setValue={setValue}
         isTutor={isTutor}
+        isDisabled={isEdit}
       />
 
       <CommonTextInput
@@ -51,7 +58,11 @@ export default function FormSectionLeft({
         }}
       />
 
-      <FormatTypeSelection watch={watch} setValue={setValue} />
+      <FormatTypeSelection
+        watch={watch}
+        setValue={setValue}
+        isDisabled={isEdit}
+      />
 
       <div
         className={`relative h-fit w-full overflow-hidden duration-500 ease-in-out ${isOnline ? "max-h-0" : "max-h-screen"}`}
@@ -75,15 +86,43 @@ export default function FormSectionLeft({
           rules={{
             required: !isOnline ? "장소를 선택해주세요." : undefined,
           }}
+          disabled={isEdit}
         />
 
         <LocationIcon className='absolute right-4 top-[calc(50%+18px)] size-6 -translate-y-1/2 transform fill-gray-300' />
       </div>
 
-      <CommonImageInput
-        label='이미지'
-        onImageChange={(image: File | null) => setImage(image)}
-      />
+      {hasInitImage ? (
+        <div className='flex flex-col gap-[12px]'>
+          <p className='pl-[8px] text-body-2-normal font-medium text-gray-300'>
+            이미지
+          </p>
+          <div className='group relative flex h-[120px] w-[120px] cursor-pointer items-center justify-center rounded-[12px] border border-gray-800 bg-gray-900'>
+            <Image
+              src={initImage!}
+              alt='Image Preview'
+              width={120}
+              height={120}
+              sizes='(max-width: 640px) 100vw, (max-width: 768px) 100vw, (max-width: 1024px) 100vw, 120px'
+              className='h-[120px] w-[120px] rounded-[12px] object-cover group-hover:brightness-50'
+            />
+
+            <div
+              className='absolute inset-0 flex size-full items-center justify-center'
+              onClick={() => {
+                setRemovedInitImage?.(true);
+                setHasInitImage(false);
+              }}
+            >
+              <div className='left-12 top-12 z-10 hidden h-[24px] w-[24px] items-center justify-center rounded-[7px] bg-[#28292E] p-1 text-center text-label-normal font-semibold text-[#C4C4C4] group-hover:block'>
+                X
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <CommonImageInput label='이미지' />
+      )}
     </section>
   );
 }

--- a/src/components/create/FormSectionLeft.tsx
+++ b/src/components/create/FormSectionLeft.tsx
@@ -34,11 +34,10 @@ export default function FormSectionLeft({
   const [hasInitImage, setHasInitImage] = useState(!!initImage);
 
   useEffect(() => {
-    if (isOnline) {
-      setValue("location", null);
-    } else {
-      if (watch("location") === null) setValue("location", "");
-    }
+    setValue(
+      "location",
+      isOnline ? null : watch("location") === null ? "" : watch("location"),
+    );
   }, [isOnline, setValue]);
 
   return (

--- a/src/components/create/FormSectionRight.tsx
+++ b/src/components/create/FormSectionRight.tsx
@@ -6,8 +6,8 @@ import type {
   UseFormWatch,
 } from "react-hook-form";
 import SolidButton from "../common/buttons/SolidButton";
+import CommonTextArea from "../common/inputs/TextArea";
 import { DateInputSection } from "./inputs/DateInputSection";
-import { MeetingTypeSection } from "./inputs/MeetingTypeSection";
 import { ParticipantsInput } from "./inputs/ParticipantsInput";
 import { type MeetupFormType } from "@/types/meetup.type";
 interface FormSectionRightProps {
@@ -44,10 +44,15 @@ export default function FormSectionRight({
 
   return (
     <section className='flex flex-1 flex-col gap-10'>
-      <MeetingTypeSection
-        watch={watch}
-        setValue={setValue}
-        isOnline={watch("isOnline")}
+      <CommonTextArea
+        required={true}
+        name='content'
+        label='본문'
+        control={control}
+        rules={{
+          required: "내용을 입력해주세요.",
+        }}
+        className='h-40 max-h-40 resize-none bg-gray-950'
       />
 
       <DateInputSection
@@ -90,11 +95,35 @@ export default function FormSectionRight({
         hasError={Boolean(methods.formState.errors.minParticipants)}
         onDecrease={() => {
           if (watch("minParticipants") === 2) return;
-          setValue("minParticipants", watch("minParticipants") - 1);
+          if (watch("minParticipants") < 2) {
+            setValue("minParticipants", 2, { shouldValidate: true });
+            return;
+          }
+          if (watch("minParticipants") > watch("maxParticipants")) {
+            setValue("minParticipants", watch("maxParticipants"), {
+              shouldValidate: true,
+            });
+            return;
+          }
+          setValue("minParticipants", watch("minParticipants") - 1, {
+            shouldValidate: true,
+          });
         }}
         onIncrease={() => {
           if (watch("minParticipants") === watch("maxParticipants")) return;
-          setValue("minParticipants", watch("minParticipants") + 1);
+          if (watch("minParticipants") > watch("maxParticipants")) {
+            setValue("minParticipants", watch("maxParticipants"), {
+              shouldValidate: true,
+            });
+            return;
+          }
+          if (typeof watch("minParticipants") !== "number") {
+            setValue("minParticipants", 2, { shouldValidate: true });
+            return;
+          }
+          setValue("minParticipants", watch("minParticipants") + 1, {
+            shouldValidate: true,
+          });
         }}
       />
 
@@ -107,11 +136,37 @@ export default function FormSectionRight({
         hasError={Boolean(methods.formState.errors.maxParticipants)}
         onDecrease={() => {
           if (watch("maxParticipants") === watch("minParticipants")) return;
-          setValue("maxParticipants", watch("maxParticipants") - 1);
+          if (watch("maxParticipants") < watch("minParticipants")) {
+            setValue("maxParticipants", watch("minParticipants"), {
+              shouldValidate: true,
+            });
+            return;
+          }
+          if (watch("maxParticipants") > 10) {
+            setValue("maxParticipants", 10, {
+              shouldValidate: true,
+            });
+            return;
+          }
+          setValue("maxParticipants", watch("maxParticipants") - 1, {
+            shouldValidate: true,
+          });
         }}
         onIncrease={() => {
           if (watch("maxParticipants") === 10) return;
-          setValue("maxParticipants", watch("maxParticipants") + 1);
+          if (typeof watch("maxParticipants") !== "number") {
+            setValue("maxParticipants", 10, { shouldValidate: true });
+            return;
+          }
+          if (watch("maxParticipants") < watch("minParticipants")) {
+            setValue("maxParticipants", watch("minParticipants"), {
+              shouldValidate: true,
+            });
+            return;
+          }
+          setValue("maxParticipants", watch("maxParticipants") + 1, {
+            shouldValidate: true,
+          });
         }}
       />
 

--- a/src/components/create/FormSectionRight.tsx
+++ b/src/components/create/FormSectionRight.tsx
@@ -16,6 +16,7 @@ interface FormSectionRightProps {
   control: Control<MeetupFormType>;
   methods: UseFormReturn<MeetupFormType>;
   isSubmitDisabled: boolean;
+  isEdit?: boolean;
 }
 
 export default function FormSectionRight({
@@ -24,19 +25,21 @@ export default function FormSectionRight({
   control,
   methods,
   isSubmitDisabled,
+  isEdit,
 }: FormSectionRightProps) {
   const [dateError, setDateError] = useState<string | undefined>(undefined);
 
   const validateDates = (
     recruitmentEndDate: Date | null,
     meetingStartDate: Date | null,
+    message: string,
   ) => {
     if (
       recruitmentEndDate &&
       meetingStartDate &&
       meetingStartDate < recruitmentEndDate
     ) {
-      setDateError("진행 기간은 모집 기간보다 과거일 수 없습니다.");
+      setDateError(message);
     } else {
       setDateError(undefined);
     }
@@ -63,11 +66,16 @@ export default function FormSectionRight({
         }}
         onChange={(date) => {
           setValue("recruitmentEndDate", date.endDate);
-          validateDates(date.endDate, watch("meetingStartDate"));
+          validateDates(
+            date.endDate,
+            watch("meetingStartDate"),
+            "모집 기간은 진행 기간보다 미래일 수 없습니다.",
+          );
         }}
         errorMessage={dateError}
         watch={watch}
         setValue={setValue}
+        isDisabled={isEdit}
       />
 
       <DateInputSection
@@ -79,11 +87,16 @@ export default function FormSectionRight({
         onChange={(date) => {
           setValue("meetingStartDate", date.startDate);
           setValue("meetingEndDate", date.endDate);
-          validateDates(watch("recruitmentEndDate"), date.startDate);
+          validateDates(
+            watch("recruitmentEndDate"),
+            date.startDate,
+            "진행 기간은 모집 기간보다 과거일 수 없습니다.",
+          );
         }}
         errorMessage={dateError}
         watch={watch}
         setValue={setValue}
+        isDisabled={isEdit}
       />
 
       <ParticipantsInput
@@ -93,6 +106,7 @@ export default function FormSectionRight({
         name='minParticipants'
         label='최소 인원'
         hasError={Boolean(methods.formState.errors.minParticipants)}
+        isDisabled={isEdit}
         onDecrease={() => {
           if (watch("minParticipants") === 2) return;
           if (watch("minParticipants") < 2) {
@@ -134,6 +148,7 @@ export default function FormSectionRight({
         name='maxParticipants'
         label='모집 인원'
         hasError={Boolean(methods.formState.errors.maxParticipants)}
+        isDisabled={isEdit}
         onDecrease={() => {
           if (watch("maxParticipants") === watch("minParticipants")) return;
           if (watch("maxParticipants") < watch("minParticipants")) {

--- a/src/components/create/MeetupFormLeft.tsx
+++ b/src/components/create/MeetupFormLeft.tsx
@@ -13,7 +13,7 @@ import MeetingTypeSelection from "./inputs/MeetingTypeSelection";
 import LocationIcon from "@/assets/images/icons/location.svg";
 import { type MeetupFormType } from "@/types/meetup.type";
 
-export default function FormSectionLeft({
+export default function MeetupFormLeft({
   initImage,
   control,
   watch,

--- a/src/components/create/MeetupFormRight.tsx
+++ b/src/components/create/MeetupFormRight.tsx
@@ -11,7 +11,7 @@ import { DateInputSection } from "./inputs/DateInputSection";
 import { ParticipantsInput } from "./inputs/ParticipantsInput";
 import { type MeetupFormType } from "@/types/meetup.type";
 
-interface FormSectionRightProps {
+interface MeetupFormRightProps {
   watch: UseFormWatch<MeetupFormType>;
   setValue: UseFormSetValue<MeetupFormType>;
   control: Control<MeetupFormType>;
@@ -20,14 +20,14 @@ interface FormSectionRightProps {
   isEdit?: boolean;
 }
 
-export default function FormSectionRight({
+export default function MeetupFormRight({
   watch,
   setValue,
   control,
   methods,
   isSubmitDisabled,
   isEdit,
-}: FormSectionRightProps) {
+}: MeetupFormRightProps) {
   const [dateError, setDateError] = useState<string | undefined>(undefined);
 
   const validateDates = useCallback(

--- a/src/components/create/inputs/DateInputSection.tsx
+++ b/src/components/create/inputs/DateInputSection.tsx
@@ -9,6 +9,7 @@ interface DateInputSectionProps
   initDate: DateRange;
   onChange: (date: DateRange) => void;
   errorMessage?: string;
+  isDisabled?: boolean;
 }
 
 export function DateInputSection({
@@ -16,6 +17,7 @@ export function DateInputSection({
   initDate,
   onChange,
   errorMessage,
+  isDisabled,
 }: DateInputSectionProps) {
   return (
     <div className='flex flex-col'>
@@ -23,9 +25,17 @@ export function DateInputSection({
         {label}
       </label>
       {label === "모집 기간" ? (
-        <RecruitmentDateInput initDate={initDate} onChange={onChange} />
+        <RecruitmentDateInput
+          initDate={initDate}
+          onChange={onChange}
+          isDisabled={isDisabled}
+        />
       ) : (
-        <MeetingDateInput initDate={initDate} onChange={onChange} />
+        <MeetingDateInput
+          initDate={initDate}
+          onChange={onChange}
+          isDisabled={isDisabled}
+        />
       )}
       <span
         className={`px-2 pt-2 text-label-normal font-medium ${errorMessage ? "text-danger" : "text-gray-500"}`}

--- a/src/components/create/inputs/FormatTypeSelection.tsx
+++ b/src/components/create/inputs/FormatTypeSelection.tsx
@@ -1,14 +1,13 @@
 import { type BaseFormProps } from "@/types/meetup.type";
 
-interface MeetingTypeProps extends Pick<BaseFormProps, "watch" | "setValue"> {
-  isOnline: boolean;
-}
-
-export function MeetingTypeSection({ watch, setValue }: MeetingTypeProps) {
+export function FormatTypeSelection({
+  watch,
+  setValue,
+}: Pick<BaseFormProps, "watch" | "setValue">) {
   return (
     <div className='flex flex-col gap-3'>
       <label className='flex h-5 px-2 text-body-2-normal font-medium text-gray-300 after:ml-0.5 after:mt-0.5 after:text-danger after:content-["*"]'>
-        모임 유형
+        모임 장소
       </label>
       <div className='flex gap-[.6875rem]'>
         <button

--- a/src/components/create/inputs/FormatTypeSelection.tsx
+++ b/src/components/create/inputs/FormatTypeSelection.tsx
@@ -1,9 +1,15 @@
 import { type BaseFormProps } from "@/types/meetup.type";
 
+interface FormatTypeSelectionProps
+  extends Pick<BaseFormProps, "watch" | "setValue"> {
+  isDisabled?: boolean;
+}
+
 export function FormatTypeSelection({
   watch,
   setValue,
-}: Pick<BaseFormProps, "watch" | "setValue">) {
+  isDisabled = false,
+}: FormatTypeSelectionProps) {
   return (
     <div className='flex flex-col gap-3'>
       <label className='flex h-5 px-2 text-body-2-normal font-medium text-gray-300 after:ml-0.5 after:mt-0.5 after:text-danger after:content-["*"]'>
@@ -12,6 +18,7 @@ export function FormatTypeSelection({
       <div className='flex gap-[.6875rem]'>
         <button
           type='button'
+          disabled={isDisabled}
           onClick={() => {
             if (watch("isOnline") === true) return;
             setValue("isOnline", true);
@@ -22,6 +29,7 @@ export function FormatTypeSelection({
         </button>
         <button
           type='button'
+          disabled={isDisabled}
           onClick={() => {
             if (watch("isOnline") === false) return;
             setValue("isOnline", false);

--- a/src/components/create/inputs/MeetingDateInput.tsx
+++ b/src/components/create/inputs/MeetingDateInput.tsx
@@ -9,9 +9,11 @@ import modal from "@/utils/modalController";
 export default function MeetingDateInput({
   initDate,
   onChange,
+  isDisabled,
 }: {
   initDate: DateType;
   onChange: (date: DateType) => void;
+  isDisabled?: boolean;
 }) {
   const [selectedDate, setSelectedDate] = useState<DateType>(
     initDate ?? {
@@ -41,7 +43,8 @@ export default function MeetingDateInput({
       <button
         type='button'
         onClick={handleClick}
-        className='relative flex h-[3.375rem] flex-1 items-center rounded-xl border border-gray-800 bg-gray-900 px-4 py-[1.125rem] text-gray-400'
+        disabled={isDisabled}
+        className={`relative flex h-[3.375rem] flex-1 items-center rounded-xl border border-gray-800 bg-gray-900 px-4 py-[1.125rem] text-body-2-normal font-medium ${selectedDate.startDate ? "border-2 border-primary text-gray-200" : "text-gray-400"}`}
       >
         {selectedDate.startDate
           ? selectedDate.startDate.toLocaleDateString()
@@ -56,7 +59,8 @@ export default function MeetingDateInput({
       <button
         type='button'
         onClick={handleClick}
-        className='relative flex h-[3.375rem] flex-1 items-center rounded-xl border border-gray-800 bg-gray-900 px-4 py-[1.125rem] text-gray-400'
+        disabled={isDisabled}
+        className={`relative flex h-[3.375rem] flex-1 items-center rounded-xl border border-gray-800 bg-gray-900 px-4 py-[1.125rem] text-body-2-normal font-medium ${selectedDate.endDate ? "border-2 border-primary text-gray-200" : "text-gray-400"}`}
       >
         {selectedDate.endDate
           ? selectedDate.endDate.toLocaleDateString()

--- a/src/components/create/inputs/MeetingTypeSelection.tsx
+++ b/src/components/create/inputs/MeetingTypeSelection.tsx
@@ -1,0 +1,45 @@
+import { type BaseFormProps } from "@/types/meetup.type";
+
+interface MeetingTypeProps extends Pick<BaseFormProps, "watch" | "setValue"> {
+  isTutor: boolean;
+}
+
+export default function MeetingTypeSelection({
+  watch,
+  setValue,
+  isTutor,
+}: MeetingTypeProps) {
+  return (
+    <div className='flex flex-col gap-3'>
+      <label className='flex h-5 px-2 text-body-2-normal font-medium text-gray-300 after:ml-0.5 after:mt-0.5 after:text-danger after:content-["*"]'>
+        모임 유형
+      </label>
+      <div className='flex gap-[.6875rem]'>
+        <button
+          type='button'
+          onClick={() => {
+            if (watch("meetingType") === "STUDY") return;
+            setValue("meetingType", "STUDY");
+          }}
+          className={`${watch("meetingType") === "STUDY" ? "bg-orange-300 text-gray-100" : "bg-gray-800 text-gray-300"} h-[3.375rem] flex-1 rounded-2xl text-body-2-normal font-semibold transition-colors duration-300`}
+        >
+          스터디
+        </button>
+        {isTutor ? (
+          <button
+            type='button'
+            onClick={() => {
+              if (watch("meetingType") === "TUTORING") return;
+              setValue("meetingType", "TUTORING");
+            }}
+            className={`${watch("meetingType") === "TUTORING" ? "bg-orange-300 text-gray-100" : "bg-gray-800 text-gray-300"} h-[3.375rem] flex-1 rounded-2xl text-body-2-normal font-semibold transition-colors duration-300`}
+          >
+            과외
+          </button>
+        ) : (
+          <div className='flex-1' />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/create/inputs/MeetingTypeSelection.tsx
+++ b/src/components/create/inputs/MeetingTypeSelection.tsx
@@ -2,12 +2,14 @@ import { type BaseFormProps } from "@/types/meetup.type";
 
 interface MeetingTypeProps extends Pick<BaseFormProps, "watch" | "setValue"> {
   isTutor: boolean;
+  isDisabled: boolean;
 }
 
 export default function MeetingTypeSelection({
   watch,
   setValue,
   isTutor,
+  isDisabled: isLocked,
 }: MeetingTypeProps) {
   return (
     <div className='flex flex-col gap-3'>
@@ -17,8 +19,9 @@ export default function MeetingTypeSelection({
       <div className='flex gap-[.6875rem]'>
         <button
           type='button'
+          disabled={isLocked}
           onClick={() => {
-            if (watch("meetingType") === "STUDY") return;
+            if (isLocked || watch("meetingType") === "STUDY") return;
             setValue("meetingType", "STUDY");
           }}
           className={`${watch("meetingType") === "STUDY" ? "bg-orange-300 text-gray-100" : "bg-gray-800 text-gray-300"} h-[3.375rem] flex-1 rounded-2xl text-body-2-normal font-semibold transition-colors duration-300`}
@@ -28,8 +31,9 @@ export default function MeetingTypeSelection({
         {isTutor ? (
           <button
             type='button'
+            disabled={isLocked}
             onClick={() => {
-              if (watch("meetingType") === "TUTORING") return;
+              if (isLocked || watch("meetingType") === "TUTORING") return;
               setValue("meetingType", "TUTORING");
             }}
             className={`${watch("meetingType") === "TUTORING" ? "bg-orange-300 text-gray-100" : "bg-gray-800 text-gray-300"} h-[3.375rem] flex-1 rounded-2xl text-body-2-normal font-semibold transition-colors duration-300`}

--- a/src/components/create/inputs/ParticipantsInput.tsx
+++ b/src/components/create/inputs/ParticipantsInput.tsx
@@ -8,6 +8,7 @@ interface ParticipantsInputProps extends BaseFormProps {
   name: "minParticipants" | "maxParticipants";
   label: string;
   hasError: boolean;
+  isDisabled?: boolean;
   onDecrease: () => void;
   onIncrease: () => void;
 }
@@ -17,6 +18,7 @@ export function ParticipantsInput({
   name,
   label,
   hasError,
+  isDisabled,
   onDecrease,
   onIncrease,
   watch,
@@ -36,6 +38,7 @@ export function ParticipantsInput({
           name={name}
           label={label}
           control={control}
+          disabled={isDisabled}
           rules={{
             required: `${label}을 입력해주세요.`,
             max: {
@@ -54,10 +57,10 @@ export function ParticipantsInput({
         />
       </div>
       <div className='flex w-[9.375rem] items-center gap-1.5'>
-        <SolidButton type='button' onClick={onDecrease}>
+        <SolidButton type='button' disabled={isDisabled} onClick={onDecrease}>
           <MinusIcon className='size-6 fill-gray-300' />
         </SolidButton>
-        <SolidButton type='button' onClick={onIncrease}>
+        <SolidButton type='button' disabled={isDisabled} onClick={onIncrease}>
           <PlusIcon className='size-6 fill-gray-300' />
         </SolidButton>
       </div>

--- a/src/components/create/inputs/RecruitmentDateInput.tsx
+++ b/src/components/create/inputs/RecruitmentDateInput.tsx
@@ -9,9 +9,11 @@ import modal from "@/utils/modalController";
 export default function RecruitmentDateInput({
   initDate,
   onChange,
+  isDisabled,
 }: {
   initDate: DateType;
   onChange: (date: DateType) => void;
+  isDisabled?: boolean;
 }) {
   const [selectedDate, setSelectedDate] = useState<DateType>({
     startDate: initDate.startDate ?? new Date(),
@@ -41,7 +43,8 @@ export default function RecruitmentDateInput({
     <button
       type='button'
       onClick={handleClick}
-      className='relative flex h-[3.375rem] items-center rounded-xl border border-gray-800 bg-gray-900 px-4 py-[1.125rem] text-gray-400'
+      disabled={isDisabled}
+      className={`relative flex h-[3.375rem] flex-1 items-center rounded-xl border border-gray-800 bg-gray-900 px-4 py-[1.125rem] text-body-2-normal font-medium ${selectedDate.endDate ? "border-2 border-primary text-gray-200" : "text-gray-400"}`}
     >
       {selectedDate.endDate
         ? selectedDate.endDate.toLocaleDateString()

--- a/src/components/create/modals/ResultInfoModal.tsx
+++ b/src/components/create/modals/ResultInfoModal.tsx
@@ -2,21 +2,25 @@ import { useRouter } from "next/navigation";
 import SolidButton from "@/components/common/buttons/SolidButton";
 
 export function SuccessModal({
-  data,
+  meetupId,
   close,
+  isEdit = false,
 }: {
-  data: { data: { meetupId: number } };
+  meetupId: number;
   close: () => void;
+  isEdit?: boolean;
 }) {
   const router = useRouter();
+
+  const type = isEdit ? "수정" : "개설";
 
   return (
     <div className='flex w-[17.6875rem] flex-col items-center p-6'>
       <p className='pb-3 text-heading-2 font-medium text-gray-100'>
-        모임 개설 완료
+        모임 {type} 완료
       </p>
       <p className='pb-6 text-body-2-normal font-medium text-gray-400'>
-        모임 개설이 완료되었어요
+        모임 {type}이 완료되었어요
       </p>
       <div className='flex w-full gap-[.4375rem]'>
         <SolidButton
@@ -24,13 +28,14 @@ export function SuccessModal({
             close();
             router.push("/");
           }}
+          mode='special'
         >
           목록으로
         </SolidButton>
         <SolidButton
           onClick={() => {
             close();
-            router.push(`/study/${data.data.meetupId}`);
+            router.push(`/study/${meetupId}`);
           }}
           state='activated'
         >
@@ -41,17 +46,25 @@ export function SuccessModal({
   );
 }
 
-export function FailModal({ close }: { close: () => void }) {
+export function FailModal({
+  title,
+  message,
+  close,
+}: {
+  title: string;
+  message: string;
+  close: () => void;
+}) {
   return (
     <div className='flex w-[17.6875rem] flex-col items-center p-6'>
-      <p className='pb-3 text-heading-2 font-medium text-gray-100'>
-        모임 개설 실패
-      </p>
+      <p className='pb-3 text-heading-2 font-medium text-gray-100'>{title}</p>
       <p className='pb-6 text-body-2-normal font-medium text-gray-400'>
-        모임 개설 중 오류가 발생했어요.
+        {message}
       </p>
       <div className='flex w-full gap-[.4375rem]'>
-        <SolidButton onClick={close}>닫기</SolidButton>
+        <SolidButton mode='special' onClick={close}>
+          닫기
+        </SolidButton>
       </div>
     </div>
   );

--- a/src/hooks/forms/useMeetupForm.tsx
+++ b/src/hooks/forms/useMeetupForm.tsx
@@ -1,0 +1,136 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useForm, type SubmitHandler } from "react-hook-form";
+import { useShallow } from "zustand/shallow";
+import { useIndexedDB } from "../inputs/images/useIndexedDB";
+import useMeetupMutations from "../meetup/useMeetupMutations";
+import { useGetProfile } from "../user/useProfile";
+import { FailModal } from "@/components/create/modals/ResultInfoModal";
+import useCookie from "@/hooks/auths/useTokenState";
+import { fetchMeetupData } from "@/lib/meetDetail/meetDetailApi";
+import useUserStore from "@/store/auth/useUserStore";
+import { type MeetProps } from "@/types/meetDetail";
+import { type MeetupFormType } from "@/types/meetup.type";
+import compareDates from "@/utils/compareDates";
+import getDefaultValues from "@/utils/meetupDefault";
+import modal from "@/utils/modalController";
+
+const useMeetupData = (id?: number) => {
+  return useQuery<{ data: MeetProps }>({
+    queryKey: ["meetup", id],
+    queryFn: () => fetchMeetupData(id!),
+    enabled: !!id,
+  });
+};
+
+export const useMeetupForm = (id?: number) => {
+  const isEdit = !!id;
+  const { data } = useMeetupData(id);
+  const meetupData = data?.data;
+  const userId = useUserStore(useShallow((state) => state.user?.userId));
+  const { loadImage } = useIndexedDB();
+  const [removedInitImage, setRemovedInitImage] = useState(false);
+  const { createMeetupMutation, editMeetupMutation } = useMeetupMutations(id);
+  const accessToken = useCookie("accessToken");
+  const userInfo = useGetProfile(userId!, accessToken!);
+
+  const methods = useForm<MeetupFormType>({
+    defaultValues: getDefaultValues(meetupData),
+    mode: "onChange",
+  });
+
+  const handleFormData = async (data: MeetupFormType, image: File | null) => {
+    const formData = new FormData();
+    const jsonBlob = new Blob([JSON.stringify(data)], {
+      type: "application/json",
+    });
+    formData.append("request", jsonBlob);
+
+    if (image) {
+      formData.append("image", image);
+    } else if (removedInitImage) {
+      formData.append("image", "");
+    }
+
+    return formData;
+  };
+
+  const checkForChanges = (data: MeetupFormType) => {
+    return Object.entries(data).some(([key, value]) => {
+      const compareKey = key === "isOnline" ? "online" : key;
+      if (
+        [
+          "recruitmentStartDate",
+          "recruitmentEndDate",
+          "meetingStartDate",
+          "meetingEndDate",
+        ].includes(key) &&
+        value instanceof Date &&
+        meetupData?.[compareKey as keyof MeetProps]
+      ) {
+        const originalDate = new Date(
+          meetupData[compareKey as keyof MeetProps] as string,
+        );
+        return !compareDates(value, originalDate);
+      }
+      return value !== meetupData?.[compareKey as keyof MeetProps];
+    });
+  };
+
+  const onSubmit: SubmitHandler<MeetupFormType> = async (data) => {
+    if (editMeetupMutation.isPending || createMeetupMutation.isPending) return;
+
+    const image = await loadImage();
+
+    try {
+      if (isEdit) {
+        const hasChanges = checkForChanges(data);
+        if (!hasChanges && !image && !removedInitImage) {
+          modal.open(
+            ({ close }) => (
+              <FailModal
+                close={close}
+                title='모임 수정 실패'
+                message='변경된 내용이 없습니다.'
+              />
+            ),
+            {
+              hasCloseBtn: false,
+              isBottom: false,
+            },
+          );
+          return;
+        }
+
+        const formData = await handleFormData(data, image);
+        await editMeetupMutation.mutateAsync(formData);
+      } else {
+        const formData = await handleFormData(data, image);
+        await createMeetupMutation.mutateAsync(formData);
+      }
+    } catch (error) {
+      console.error("Error creating meetup:", error);
+    }
+  };
+
+  const isSubmitDisabled =
+    methods.watch("title") === "" ||
+    methods.watch("content") === "" ||
+    methods.watch("recruitmentEndDate") === null ||
+    methods.watch("meetingStartDate") === null ||
+    methods.watch("meetingEndDate") === null ||
+    (methods.watch("isOnline") === false && methods.watch("location") === null);
+
+  return {
+    methods,
+    onSubmit,
+    isSubmitDisabled,
+    isEdit,
+    meetupData,
+    userInfo,
+    control: methods.control,
+    watch: methods.watch,
+    setValue: methods.setValue,
+    setRemovedInitImage,
+  };
+};

--- a/src/hooks/inputs/images/useIndexedDB.ts
+++ b/src/hooks/inputs/images/useIndexedDB.ts
@@ -41,7 +41,7 @@ export const useIndexedDB = () => {
     }
   };
 
-  const loadImage = async () => {
+  const loadImage = async (): Promise<File | null> => {
     try {
       const db = await initDB();
       const tx = db.transaction(STORE_NAME, "readonly");

--- a/src/hooks/inputs/images/useUploadImage.ts
+++ b/src/hooks/inputs/images/useUploadImage.ts
@@ -47,8 +47,8 @@ export const useUploadImage = () => {
   };
 
   // 이미지 삭제 처리
-  const handleImageDelete = async (event: React.MouseEvent) => {
-    event.stopPropagation(); // 부모 클릭 방지 (input 파일 선택)
+  const handleImageDelete = async (event?: React.MouseEvent) => {
+    if (event) event.stopPropagation(); // 부모 클릭 방지 (input 파일 선택)
     try {
       await deleteImage();
       setImage(null);

--- a/src/hooks/meetup/useMeetupMutations.tsx
+++ b/src/hooks/meetup/useMeetupMutations.tsx
@@ -1,0 +1,62 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useIndexedDB } from "../inputs/images/useIndexedDB";
+import {
+  FailModal,
+  SuccessModal,
+} from "@/components/create/modals/ResultInfoModal";
+import { createMeetup, editMeetup } from "@/lib/main/meetup.api";
+import modal from "@/utils/modalController";
+
+const useMeetupMutations = (id?: number) => {
+  const queryClient = useQueryClient();
+  const { deleteImage } = useIndexedDB();
+
+  const commonOnSuccess = async (meetupId: number) => {
+    await deleteImage();
+    queryClient.invalidateQueries({ queryKey: ["meetup"] });
+    modal.open(
+      ({ close }) => <SuccessModal meetupId={meetupId} close={close} />,
+      {
+        hasCloseBtn: false,
+        isBottom: false,
+        disableOverlayClick: true,
+      },
+    );
+  };
+
+  const commonOnError = (title: string, message: string) => {
+    modal.open(
+      ({ close }) => (
+        <FailModal title={title} message={message} close={close} />
+      ),
+      {
+        hasCloseBtn: false,
+        isBottom: false,
+      },
+    );
+  };
+
+  const createMeetupMutation = useMutation({
+    mutationFn: createMeetup,
+    onSuccess: async (data: { data: { meetupId: number } }) => {
+      await commonOnSuccess(data.data.meetupId);
+    },
+    onError: () => {
+      commonOnError("모임 개설 실패", "모임 개설 중 오류가 발생했어요");
+    },
+  });
+
+  const editMeetupMutation = useMutation({
+    mutationFn: (formData: FormData) => editMeetup({ id: id!, formData }),
+    onSuccess: async () => {
+      await commonOnSuccess(id!);
+    },
+    onError: () => {
+      commonOnError("모임 수정 실패", "모임 수정 중 오류가 발생했어요");
+    },
+  });
+
+  return { createMeetupMutation, editMeetupMutation };
+};
+
+export default useMeetupMutations;

--- a/src/hooks/meetup/useMeetupMutations.tsx
+++ b/src/hooks/meetup/useMeetupMutations.tsx
@@ -11,11 +11,13 @@ const useMeetupMutations = (id?: number) => {
   const queryClient = useQueryClient();
   const { deleteImage } = useIndexedDB();
 
-  const commonOnSuccess = async (meetupId: number) => {
+  const commonOnSuccess = async (meetupId: number, isEdit = false) => {
     await deleteImage();
     queryClient.invalidateQueries({ queryKey: ["meetup"] });
     modal.open(
-      ({ close }) => <SuccessModal meetupId={meetupId} close={close} />,
+      ({ close }) => (
+        <SuccessModal meetupId={meetupId} close={close} isEdit={isEdit} />
+      ),
       {
         hasCloseBtn: false,
         isBottom: false,
@@ -49,7 +51,7 @@ const useMeetupMutations = (id?: number) => {
   const editMeetupMutation = useMutation({
     mutationFn: (formData: FormData) => editMeetup({ id: id!, formData }),
     onSuccess: async () => {
-      await commonOnSuccess(id!);
+      await commonOnSuccess(id!, true);
     },
     onError: () => {
       commonOnError("모임 수정 실패", "모임 수정 중 오류가 발생했어요");

--- a/src/lib/main/meetup.api.ts
+++ b/src/lib/main/meetup.api.ts
@@ -82,3 +82,31 @@ export const createMeetup = async (formData: FormData) => {
 
   return await res.json();
 };
+
+export const editMeetup = async ({
+  id,
+  formData,
+}: {
+  id: number;
+  formData: FormData;
+}) => {
+  const accessToken = getAccessToken();
+
+  if (!accessToken) {
+    throw new Error("Access token is not found");
+  }
+
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/meetups/${id}`, {
+    method: "PATCH",
+    body: formData,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error("Failed to edit meetup");
+  }
+
+  return await res.json();
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -109,34 +109,4 @@
     -moz-appearance: none;
     appearance: none;
   }
-
-  @keyframes slide-in {
-    from {
-      max-height: 0;
-      opacity: 0;
-    }
-    to {
-      max-height: 500px; /* Adjust based on content */
-      opacity: 1;
-    }
-  }
-
-  @keyframes slide-out {
-    from {
-      max-height: 500px; /* Adjust based on content */
-      opacity: 1;
-    }
-    to {
-      max-height: 0;
-      opacity: 0;
-    }
-  }
-
-  .animate-slide-in {
-    animation: slide-in 0.5s forwards;
-  }
-
-  .animate-slide-out {
-    animation: slide-out 0.5s forwards;
-  }
 }

--- a/src/types/meetup.type.ts
+++ b/src/types/meetup.type.ts
@@ -17,7 +17,7 @@ export type StateType =
 
 export type LocationType =
   | "ALL"
-  | "Capital"
+  | "CAPITAL"
   | "DAEJEON"
   | "JEONJU"
   | "GWANGJU"

--- a/src/utils/compareDates.ts
+++ b/src/utils/compareDates.ts
@@ -1,0 +1,10 @@
+// 날짜 비교 유틸리티 함수
+const compareDates = (date1: Date, date2: Date) => {
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  );
+};
+
+export default compareDates;

--- a/src/utils/meetupDefault.ts
+++ b/src/utils/meetupDefault.ts
@@ -1,0 +1,34 @@
+import { type MeetProps } from "@/types/meetDetail";
+import { type MeetupFormType } from "@/types/meetup.type";
+
+const getDefaultValues = (meetupData?: MeetProps): MeetupFormType => {
+  return meetupData
+    ? {
+        title: meetupData.title,
+        meetingType: meetupData.meetingType,
+        location: meetupData.location,
+        content: meetupData.content,
+        recruitmentStartDate: new Date(meetupData.recruitmentStartDate),
+        recruitmentEndDate: new Date(meetupData.recruitmentEndDate),
+        meetingStartDate: new Date(meetupData.meetingStartDate),
+        meetingEndDate: new Date(meetupData.meetingEndDate),
+        minParticipants: meetupData.minParticipants,
+        maxParticipants: meetupData.maxParticipants,
+        isOnline: meetupData.online,
+      }
+    : {
+        title: "",
+        meetingType: "STUDY",
+        location: "",
+        content: "",
+        recruitmentStartDate: new Date(),
+        recruitmentEndDate: null,
+        meetingStartDate: null,
+        meetingEndDate: null,
+        minParticipants: 2,
+        maxParticipants: 10,
+        isOnline: false,
+      };
+};
+
+export default getDefaultValues;


### PR DESCRIPTION
## 제목 규칙
`feat(issue 번호) : 기능명` 형태로 작성하세요.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 기능 변경
- [x] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- `from`: feat/125/create-page
- `to`: develop
### 작업 내용 및 변경 사항
- 모임을 생성 할 때 사용자가 과외를 만들 권한이 있다면 과외 모임을 만들 수 있도록 버튼을 추가했습니다.
- 모임 수정 기능을 추가 했습니다.
  - 제목, 설명, 썸네일 만 수정이 가능하고 나머지는 선택이 불가능하게 만들었습니다.
  - 이미지 업로드 관련해서 indexDB를 사용하도록 수정했습니다.


### 결과 이미지(화면 캡쳐해서)

### Todo
- [ ] 추가로 작업해야 할 사항에 대해 알려주세요
### 이슈 링크
- #125 
### 리뷰어 멘션하기
- 본인 username 제외하고 PR 날려주세요
@joshuayeyo @ITHPARK @Stilllee
