### PR TITLE
Feat(#164): 모임 생성/수정 시 임시 저장 기능 추가

### DIFF
--- a/src/components/create/inputs/MeetingDateInput.tsx
+++ b/src/components/create/inputs/MeetingDateInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import MeetingDateModal from "../modals/MeetingDateModal";
 import ArrowDownIcon from "@/assets/images/icons/arrow_down_fill.svg";
 import { type DateType } from "@/types/meetup.type";
@@ -21,6 +21,12 @@ export default function MeetingDateInput({
       endDate: null,
     },
   );
+
+  useEffect(() => {
+    if (initDate) {
+      setSelectedDate(initDate);
+    }
+  }, [initDate]);
 
   const handleClick = () => {
     modal.open(

--- a/src/components/create/inputs/RecruitmentDateInput.tsx
+++ b/src/components/create/inputs/RecruitmentDateInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import RecruitmentDateModals from "../modals/RecruitmentDateModals";
 import ArrowDownIcon from "@/assets/images/icons/arrow_down_fill.svg";
 import type { DateType } from "@/types/meetup.type";
@@ -19,6 +19,12 @@ export default function RecruitmentDateInput({
     startDate: initDate.startDate ?? new Date(),
     endDate: initDate.endDate ?? null,
   });
+
+  useEffect(() => {
+    if (initDate.endDate) {
+      setSelectedDate(initDate);
+    }
+  }, [initDate]);
 
   const handleClick = () => {
     modal.open(

--- a/src/components/create/modals/ResultInfoModal.tsx
+++ b/src/components/create/modals/ResultInfoModal.tsx
@@ -50,10 +50,12 @@ export function FailModal({
   title,
   message,
   close,
+  btnText = "닫기",
 }: {
   title: string;
   message: string;
   close: () => void;
+  btnText?: string;
 }) {
   return (
     <div className='flex w-[17.6875rem] flex-col items-center p-6'>
@@ -63,7 +65,7 @@ export function FailModal({
       </p>
       <div className='flex w-full gap-[.4375rem]'>
         <SolidButton mode='special' onClick={close}>
-          닫기
+          {btnText}
         </SolidButton>
       </div>
     </div>

--- a/src/hooks/forms/useLocalStorageForm.ts
+++ b/src/hooks/forms/useLocalStorageForm.ts
@@ -1,0 +1,94 @@
+import { useEffect } from "react";
+import { type UseFormReturn } from "react-hook-form";
+import { type MeetupFormType } from "@/types/meetup.type";
+
+export const useLocalStorageForm = (
+  methods: UseFormReturn<MeetupFormType>,
+  tempKey: string,
+) => {
+  // 초기값을 로컬스토리지에서 불러오기
+  useEffect(() => {
+    const loadStoredData = async () => {
+      const storedData = localStorage.getItem(tempKey);
+      if (!storedData) return;
+
+      try {
+        const parsedData = JSON.parse(storedData);
+
+        if (
+          parsedData.expiration &&
+          new Date(parsedData.expiration) < new Date()
+        ) {
+          localStorage.removeItem(tempKey);
+          return;
+        }
+
+        const recruitmentStartDate = parsedData.recruitmentStartDate
+          ? new Date(parsedData.recruitmentStartDate)
+          : null;
+        const recruitmentEndDate = parsedData.recruitmentEndDate
+          ? new Date(parsedData.recruitmentEndDate)
+          : null;
+        const meetingStartDate = parsedData.meetingStartDate
+          ? new Date(parsedData.meetingStartDate)
+          : null;
+        const meetingEndDate = parsedData.meetingEndDate
+          ? new Date(parsedData.meetingEndDate)
+          : null;
+
+        methods.reset({
+          ...parsedData,
+          recruitmentStartDate,
+          recruitmentEndDate,
+          meetingStartDate,
+          meetingEndDate,
+        });
+      } catch (error) {
+        console.error("Failed to load stored data:", error);
+      }
+    };
+
+    loadStoredData();
+  }, []);
+
+  // 폼 데이터를 로컬스토리지에 저장하기
+  useEffect(() => {
+    const subscription = methods.watch((value) => {
+      const expirationDate = new Date();
+      expirationDate.setDate(expirationDate.getDate() + 2);
+      localStorage.setItem(
+        tempKey,
+        JSON.stringify({
+          ...value,
+          recruitmentStartDate: value.recruitmentStartDate?.toISOString(),
+          recruitmentEndDate: value.recruitmentEndDate?.toISOString(),
+          meetingStartDate: value.meetingStartDate?.toISOString(),
+          meetingEndDate: value.meetingEndDate?.toISOString(),
+          expiration: expirationDate.toISOString(),
+        }),
+      );
+    });
+    return () => subscription.unsubscribe();
+  }, [methods.watch, tempKey]);
+
+  // 탭을 닫거나 새로고침할 때 로컬스토리지에서 임시 데이터 삭제
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (localStorage.getItem(tempKey)) {
+        event.preventDefault();
+      }
+    };
+
+    const handleUnload = () => {
+      localStorage.removeItem(tempKey);
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    window.addEventListener("unload", handleUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      window.removeEventListener("unload", handleUnload);
+    };
+  }, [tempKey]);
+};

--- a/src/hooks/forms/useMeetupForm.tsx
+++ b/src/hooks/forms/useMeetupForm.tsx
@@ -1,19 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
-import { useShallow } from "zustand/shallow";
-import { useIndexedDB } from "../inputs/images/useIndexedDB";
-import useMeetupMutations from "../meetup/useMeetupMutations";
-import { useGetProfile } from "../user/useProfile";
+import { useLocalStorageForm } from "./useLocalStorageForm";
+import { useMeetupPermissions } from "./useMeetupPermissions";
 import { FailModal } from "@/components/create/modals/ResultInfoModal";
 import useCookie from "@/hooks/auths/useTokenState";
+import { useIndexedDB } from "@/hooks/inputs/images/useIndexedDB";
+import useMeetupMutations from "@/hooks/meetup/useMeetupMutations";
+import { useGetProfile } from "@/hooks/user/useProfile";
 import { fetchMeetupData } from "@/lib/meetDetail/meetDetailApi";
-import useUserStore from "@/store/auth/useUserStore";
 import { type MeetProps } from "@/types/meetDetail";
 import { type MeetupFormType } from "@/types/meetup.type";
-import compareDates from "@/utils/compareDates";
 import getDefaultValues from "@/utils/meetupDefault";
+import { checkForChanges, prepareFormData } from "@/utils/meetupHelpers";
 import modal from "@/utils/modalController";
 
 const useMeetupData = (id?: number) => {
@@ -28,78 +27,20 @@ export const useMeetupForm = (id?: number) => {
   const isEdit = !!id;
   const { data } = useMeetupData(id);
   const meetupData = data?.data;
-  const userId = useUserStore(useShallow((state) => state.user?.userId));
+  const { userId } = useMeetupPermissions(meetupData);
   const { loadImage } = useIndexedDB();
   const [removedInitImage, setRemovedInitImage] = useState(false);
   const { createMeetupMutation, editMeetupMutation } = useMeetupMutations(id);
   const accessToken = useCookie("accessToken");
   const userInfo = useGetProfile(userId!, accessToken!);
-  const router = useRouter();
-
-  useEffect(() => {
-    if (meetupData?.hostId !== userId) {
-      modal.open(
-        ({ close }) => (
-          <FailModal
-            close={() => {
-              close();
-              router.replace("/");
-            }}
-            title='모임 수정 실패'
-            message='본인이 개설한 모임만 수정할 수 있습니다.'
-          />
-        ),
-        {
-          hasCloseBtn: false,
-          isBottom: false,
-          disableOverlayClick: true,
-        },
-      );
-    }
-  }, [meetupData, userId, router]);
+  const tempKey = isEdit ? `meetup-edit-${id}` : "meetup-create";
 
   const methods = useForm<MeetupFormType>({
     defaultValues: getDefaultValues(meetupData),
     mode: "onChange",
   });
 
-  const handleFormData = async (data: MeetupFormType, image: File | null) => {
-    const formData = new FormData();
-    const jsonBlob = new Blob([JSON.stringify(data)], {
-      type: "application/json",
-    });
-    formData.append("request", jsonBlob);
-
-    if (image) {
-      formData.append("image", image);
-    } else if (removedInitImage) {
-      formData.append("image", "");
-    }
-
-    return formData;
-  };
-
-  const checkForChanges = (data: MeetupFormType) => {
-    return Object.entries(data).some(([key, value]) => {
-      const compareKey = key === "isOnline" ? "online" : key;
-      if (
-        [
-          "recruitmentStartDate",
-          "recruitmentEndDate",
-          "meetingStartDate",
-          "meetingEndDate",
-        ].includes(key) &&
-        value instanceof Date &&
-        meetupData?.[compareKey as keyof MeetProps]
-      ) {
-        const originalDate = new Date(
-          meetupData[compareKey as keyof MeetProps] as string,
-        );
-        return !compareDates(value, originalDate);
-      }
-      return value !== meetupData?.[compareKey as keyof MeetProps];
-    });
-  };
+  useLocalStorageForm(methods, tempKey);
 
   const onSubmit: SubmitHandler<MeetupFormType> = async (data) => {
     if (editMeetupMutation.isPending || createMeetupMutation.isPending) return;
@@ -107,9 +48,10 @@ export const useMeetupForm = (id?: number) => {
     const image = await loadImage();
 
     try {
+      const formData = await prepareFormData(data, image, removedInitImage);
+
       if (isEdit) {
-        const hasChanges = checkForChanges(data);
-        if (!hasChanges && !image && !removedInitImage) {
+        if (!checkForChanges(data, meetupData) && !image && !removedInitImage) {
           modal.open(
             ({ close }) => (
               <FailModal
@@ -118,22 +60,16 @@ export const useMeetupForm = (id?: number) => {
                 message='변경된 내용이 없습니다.'
               />
             ),
-            {
-              hasCloseBtn: false,
-              isBottom: false,
-            },
+            { hasCloseBtn: false, isBottom: false },
           );
           return;
         }
-
-        const formData = await handleFormData(data, image);
         await editMeetupMutation.mutateAsync(formData);
       } else {
-        const formData = await handleFormData(data, image);
         await createMeetupMutation.mutateAsync(formData);
       }
     } catch (error) {
-      console.error("Error creating meetup:", error);
+      console.error("Error processing meetup:", error);
     }
   };
 
@@ -147,7 +83,7 @@ export const useMeetupForm = (id?: number) => {
       methods.watch("location") === null) ||
     createMeetupMutation.isPending ||
     editMeetupMutation.isPending ||
-    (isEdit === true && meetupData?.hostId !== userId);
+    (isEdit && meetupData?.hostId !== userId);
 
   return {
     methods,

--- a/src/hooks/forms/useMeetupPermissions.tsx
+++ b/src/hooks/forms/useMeetupPermissions.tsx
@@ -1,0 +1,39 @@
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { useShallow } from "zustand/shallow";
+import { FailModal } from "@/components/create/modals/ResultInfoModal";
+import useUserStore from "@/store/auth/useUserStore";
+import { type MeetProps } from "@/types/meetDetail";
+import modal from "@/utils/modalController";
+
+export const useMeetupPermissions = (meetupData?: MeetProps) => {
+  const router = useRouter();
+  const userId = useUserStore(useShallow((state) => state.user?.userId));
+
+  if (!meetupData) return { userId };
+
+  useEffect(() => {
+    if (meetupData?.hostId !== userId) {
+      modal.open(
+        ({ close }) => (
+          <FailModal
+            close={() => {
+              close();
+              router.replace("/");
+            }}
+            title='모임 수정 실패'
+            message='본인이 개설한 모임만 수정할 수 있습니다.'
+            btnText='돌아가기'
+          />
+        ),
+        {
+          hasCloseBtn: false,
+          isBottom: false,
+          disableOverlayClick: true,
+        },
+      );
+    }
+  }, [meetupData, userId, router]);
+
+  return { userId };
+};

--- a/src/utils/meetupHelpers.ts
+++ b/src/utils/meetupHelpers.ts
@@ -1,0 +1,48 @@
+import compareDates from "./compareDates";
+import { type MeetProps } from "@/types/meetDetail";
+import { type MeetupFormType } from "@/types/meetup.type";
+
+export const checkForChanges = (
+  data: MeetupFormType,
+  meetupData?: MeetProps,
+) => {
+  return Object.entries(data).some(([key, value]) => {
+    const compareKey = key === "isOnline" ? "online" : key;
+    if (
+      [
+        "recruitmentStartDate",
+        "recruitmentEndDate",
+        "meetingStartDate",
+        "meetingEndDate",
+      ].includes(key) &&
+      value instanceof Date &&
+      meetupData?.[compareKey as keyof MeetProps]
+    ) {
+      const originalDate = new Date(
+        meetupData[compareKey as keyof MeetProps] as string,
+      );
+      return !compareDates(value, originalDate);
+    }
+    return value !== meetupData?.[compareKey as keyof MeetProps];
+  });
+};
+
+export const prepareFormData = async (
+  data: MeetupFormType,
+  image: File | null,
+  removedInitImage: boolean,
+) => {
+  const formData = new FormData();
+  const jsonBlob = new Blob([JSON.stringify(data)], {
+    type: "application/json",
+  });
+  formData.append("request", jsonBlob);
+
+  if (image) {
+    formData.append("image", image);
+  } else if (removedInitImage) {
+    formData.append("image", "");
+  }
+
+  return formData;
+};


### PR DESCRIPTION
## 제목 규칙
`feat(issue 번호) : 기능명` 형태로 작성하세요.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 기능 변경
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- `from`: feat/164/temp-meetup
- `to`: develop
### 작업 내용 및 변경 사항
- 모임 생성/수정 시 임시로 저장이 되도록 하는 기능을 추가했습니다.
- 새로고침이나 탭을 닫는 경우에 경고를 띄워주도록 했습니다.
### 결과 이미지(화면 캡쳐해서)
![image](https://github.com/user-attachments/assets/a4de154a-81b0-42b5-8004-439647c84dc6)
### Todo
- [ ] 추가로 작업해야 할 사항에 대해 알려주세요
### 이슈 링크
- close #164 
### 리뷰어 멘션하기
- 본인 username 제외하고 PR 날려주세요
@joshuayeyo @ITHPARK @Stilllee
