### PR TITLE
Fix(#239): 리뷰 카드 UI 일관성 개선

### DIFF
--- a/src/components/common/review/ReviewContent.tsx
+++ b/src/components/common/review/ReviewContent.tsx
@@ -5,6 +5,10 @@ import { type ContentProps } from "@/types/review";
 export default function Content({ reviewContent, isOpen }: ContentProps) {
   const contentStyle = isOpen ? "" : "comment-overflow comment-overflow-webkit";
 
+  // 수강평인 경우 reviewThumbnail을, 아닌 경우 thumbnail을 사용
+  const thumbnailImage =
+    reviewContent.reviewThumbnail || reviewContent.thumbnail;
+
   return (
     <div className='w-full'>
       {reviewContent.isMyReview && (
@@ -28,21 +32,19 @@ export default function Content({ reviewContent, isOpen }: ContentProps) {
         >
           {reviewContent.review}
         </p>
-        {isOpen &&
-          reviewContent.thumbnail &&
-          typeof reviewContent.thumbnail === "string" && (
-            <div className='mt-4 flex justify-end'>
-              <Image
-                className='size-20 rounded-lg object-cover'
-                src={reviewContent.thumbnail}
-                width={80}
-                height={80}
-                alt='리뷰 이미지'
-                priority
-                loading='eager'
-              />
-            </div>
-          )}
+        {isOpen && thumbnailImage && typeof thumbnailImage === "string" && (
+          <div className='mt-4 flex justify-end'>
+            <Image
+              className='size-20 rounded-lg object-cover'
+              src={thumbnailImage}
+              width={80}
+              height={80}
+              alt='리뷰 이미지'
+              priority
+              loading='eager'
+            />
+          </div>
+        )}
       </div>
       <div className='mt-4 flex justify-end'>
         <div className='flex items-center'>

--- a/src/components/common/review/ReviewContent.tsx
+++ b/src/components/common/review/ReviewContent.tsx
@@ -20,7 +20,11 @@ export default function Content({ reviewContent, isOpen }: ContentProps) {
 
       <div>
         <p
-          className={`body-2-reading mt-4 whitespace-pre-line break-keep text-gray-200 ${contentStyle}`}
+          className={`body-2-reading mt-4 min-h-[72px] w-full break-keep text-gray-200 ${
+            isOpen
+              ? "h-auto whitespace-pre-line"
+              : "line-clamp-3 h-[72px] whitespace-normal"
+          } ${contentStyle}`}
         >
           {reviewContent.review}
         </p>

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -14,6 +14,7 @@ export interface ReviewInfo {
   reviewId: number;
   editable?: boolean;
   thumbnail?: string | null;
+  reviewThumbnail?: string | null;
 }
 
 export interface ReviewInfoProps {

--- a/src/types/user-page/index.ts
+++ b/src/types/user-page/index.ts
@@ -134,6 +134,7 @@ export interface WrittenReview {
   content: string;
   meetingEndDate: string;
   thumbnail: string | null;
+  reviewThumbnail?: string | null;
   reviewDate: string;
   editabel: boolean;
 }

--- a/src/utils/userContentMapper.ts
+++ b/src/utils/userContentMapper.ts
@@ -102,6 +102,7 @@ export const mapWrittenReviewToReviewInfo = (
     reviewId: review.reviewId,
     editable: review.editabel,
     thumbnail: review.thumbnail,
+    reviewThumbnail: review.reviewThumbnail,
   };
 };
 


### PR DESCRIPTION


## 제목 규칙
`feat(issue 번호) : 기능명` 형태로 작성하세요.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 기능 변경
- [x] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- `from`: feat/issue번호/기능명
- `to`: develop
### 작업 내용 및 변경 사항
- 디바이스별 카드 높이 통일
- 텍스트 말줄임표 표시 수정
- 열린 상태에서 최소 높이 유지
- 리뷰 이미지는 열린 상태에서만 표시

### 결과 이미지(화면 캡쳐해서)
![image](https://github.com/user-attachments/assets/832f098a-d80d-4254-8f94-6dc4080ade48)

![image](https://github.com/user-attachments/assets/90063c4b-dfcf-4776-a55c-63eb4412b49f)

### Todo
- [ ] 추가로 작업해야 할 사항에 대해 알려주세요
### 이슈 링크
- #239 
### 리뷰어 멘션하기
- 본인 username 제외하고 PR 날려주세요
@joshuayeyo @ITHPARK @wjsdncl 